### PR TITLE
Fix upgrage role validation in case of force=True

### DIFF
--- a/sovrin_node/server/node.py
+++ b/sovrin_node/server/node.py
@@ -374,6 +374,7 @@ class Node(PlenumNode, HasPoolManager):
         else:
             # forced request should be processed before consensus
             if request.operation[TXN_TYPE] == POOL_UPGRADE and request.isForced():
+                self.configReqHandler.validate(request)
                 self.configReqHandler.applyForced(request)
             super().processRequest(request, frm)
 

--- a/sovrin_node/test/upgrade/test_pool_upgrade_reject.py
+++ b/sovrin_node/test/upgrade/test_pool_upgrade_reject.py
@@ -49,3 +49,9 @@ def test_accept_then_reject_upgrade(looper, trustee, trusteeWallet, validUpgrade
     looper.run(eventually(checkRejects, trustee, req.reqId,
                           'InvalidClientRequest', retryWait=1, timeout=timeout))
 
+def testOnlyTrusteeCanSendPoolUpgradeForceTrue(looper, steward, validUpgradeExpForceTrue):
+    stClient, stWallet = steward
+    _, req = sendUpgrade(stClient, stWallet, validUpgradeExpForceTrue)
+    timeout = plenumWaits.expectedReqNAckQuorumTime()
+    looper.run(eventually(checkNacks, stClient, req.reqId,
+                          'cannot do', retryWait=1, timeout=timeout))


### PR DESCRIPTION
pool_upgrade wit force=True were allowed for everyone.
The fix added a validation to allow upgrade for trustee only