### PR TITLE
Modify CLI Commands to Reflect New Terminology

### DIFF
--- a/scripts/load.py
+++ b/scripts/load.py
@@ -1,14 +1,20 @@
+import logging
+
+from plenum.common.signer_did import DidSigner
 from sovrin_client.client.client import Client
 from sovrin_client.client.wallet.wallet import Wallet
 from sovrin_common.identity import Identity
+from stp_core.common.log import getlogger, Logger
 from stp_core.network.port_dispenser import genHa, HA
 from stp_core.loop.looper import Looper
 from plenum.test.helper import waitForSufficientRepliesForRequests
 from time import *
-from plenum.common.signer_simple import SimpleSigner
 
-numReqs = 10000
-splits = 5
+numReqs = 1000
+splits = 2
+
+Logger.setLogLevel(logging.INFO)
+logger = getlogger()
 
 
 def sendRandomRequests(wallet: Wallet, client: Client, count: int):
@@ -22,13 +28,13 @@ def sendRandomRequests(wallet: Wallet, client: Client, count: int):
     return client.submitReqs(*reqs)
 
 
-def load():
+def put_load():
     port = genHa()[1]
     ha = HA('0.0.0.0', port)
     name = "hello"
     wallet = Wallet(name)
     wallet.addIdentifier(
-        signer=SimpleSigner(seed=b'000000000000000000000000Steward1'))
+        signer=DidSigner(seed=b'000000000000000000000000Steward1'))
     client = Client(name, ha=ha)
     with Looper(debug=True) as looper:
         looper.add(client)
@@ -40,7 +46,8 @@ def load():
             s = perf_counter()
             reqs = requests[i:i + numReqs // splits + 1]
             waitForSufficientRepliesForRequests(looper, client, requests=reqs,
-                                                fVal=2, customTimeoutPerReq=3)
+                                                fVal=2, customTimeoutPerReq=100,
+                                                override_timeout_limit=True)
             print('>>> Got replies for {} requests << in {}'.
                   format(numReqs // splits, perf_counter() - s))
         end = perf_counter()
@@ -49,4 +56,4 @@ def load():
 
 
 if __name__ == "__main__":
-    load()
+    put_load()

--- a/scripts/load_multi.py
+++ b/scripts/load_multi.py
@@ -1,0 +1,18 @@
+from multiprocessing import Pool, Process
+
+from scripts.load import put_load
+
+num_processes = 10
+
+
+if __name__ == '__main__':
+    # with Pool(num_processes) as p:
+    #     p.map(put_load, [])
+    processes = []
+    for _ in range(num_processes):
+        p = Process(target=put_load, )
+        p.start()
+        processes.append(p)
+
+    for p in processes:
+        p.join()

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum-dev==0.4.63',
+    install_requires=['indy-plenum-dev==0.4.64',
                       'indy-anoncreds-dev==0.4.18',
                       'python-dateutil',
                       'timeout-decorator'],

--- a/sovrin_client/agent/agent_cli.py
+++ b/sovrin_client/agent/agent_cli.py
@@ -25,7 +25,7 @@ class AgentCli(SovrinCli):
         if not self._actions:
             self._actions = [self._simpleAction, self._helpAction,
                              self._listIdsAction, self._changePrompt,
-                             self._listKeyringsAction, self._showFile,
+                             self._listWalletsAction, self._showFile,
                              self._showLink, self._pingTarget,
                              self._listLinks, self._sendProofRequest]
         return self._actions

--- a/sovrin_client/agent/walleted.py
+++ b/sovrin_client/agent/walleted.py
@@ -392,7 +392,7 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
             # and we are still missing link, then return the error
             if link is None:
                 linkNotCreated = '    Error processing {}. ' \
-                                 'Link is not yet created.'.format(typ)
+                                 'Connection is not yet created.'.format(typ)
                 self.notifyToRemoteCaller(EVENT_NOTIFY_MSG,
                                           linkNotCreated,
                                           self.wallet.defaultId,
@@ -517,7 +517,7 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
             if alreadyAccepted:
                 self.notifyMsgListener("    Already accepted.")
             else:
-                self.notifyMsgListener("    Identifier created in Sovrin.")
+                self.notifyMsgListener("    DID created in Sovrin.")
 
                 li.linkStatus = constant.LINK_STATUS_ACCEPTED
                 rcvdAvailableClaims = body[DATA][CLAIMS_LIST_FIELD]
@@ -597,11 +597,11 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
             if reply.get(DATA) and json.loads(reply[DATA])[TARGET_NYM] == \
                     li.localIdentifier:
                 self.notifyMsgListener(
-                    "    Confirmed identifier written to Sovrin.")
+                    "    Confirmed DID written to Sovrin.")
                 self.notifyEventListeners(EVENT_POST_ACCEPT_INVITE, link=li)
             else:
                 self.notifyMsgListener(
-                    "    Identifier is not yet written to Sovrin")
+                    "    DID is not yet written to Sovrin")
 
         self.loop.call_later(.2, ensureReqCompleted, self.loop, req.key,
                              self.client, getNymReply, (availableClaims, li))
@@ -792,10 +792,10 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
                                  cr[VERIFIABLE_ATTRIBUTES] if VERIFIABLE_ATTRIBUTES in cr else [],
                                  cr[PREDICATES] if PREDICATES in cr else []))
 
-        self.notifyMsgListener("1 link invitation found for {}.".
+        self.notifyMsgListener("1 connection request found for {}.".
                                format(linkInvitationName))
 
-        self.notifyMsgListener("Creating Link for {}.".
+        self.notifyMsgListener("Creating connection for {}.".
                                format(linkInvitationName))
         # TODO: Would we always have a trust anchor corresponding to a link?
 
@@ -949,7 +949,7 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
                         link.full_remote_verkey) if link.full_remote_verkey else None
 
             link.linkLastSynced = datetime.now()
-            self.notifyMsgListener("    Link {} synced".format(link.name))
+            self.notifyMsgListener("    Connection {} synced".format(link.name))
 
     def _pingToEndpoint(self, name, endpoint):
         self.notifyMsgListener("\nPinging target endpoint: {}".

--- a/sovrin_client/agent/walleted_agent.py
+++ b/sovrin_client/agent/walleted_agent.py
@@ -123,7 +123,7 @@ class WalletedAgent(Walleted, Agent, Caching):
             fileName = normalizedWalletFileName(walletName)
             walletFilePath = self.walletSaver.saveWallet(
                 wallet, getWalletFilePath(contextDir, fileName))
-            self.logger.info('Active keyring "{}" saved ({})'.
+            self.logger.info('Active wallet "{}" saved ({})'.
                              format(walletName, walletFilePath))
         except IOError as ex:
             self.logger.info("Error occurred while saving wallet. " +
@@ -135,7 +135,7 @@ class WalletedAgent(Walleted, Agent, Caching):
             self.getContextDir())
         if restoredWallet:
             self.wallet = restoredWallet
-            self.logger.info('Saved keyring "{}" restored ({})'.
+            self.logger.info('Saved wallet "{}" restored ({})'.
                              format(self.wallet.name, walletFilePath))
 
     def _restoreIssuerWallet(self):
@@ -144,7 +144,7 @@ class WalletedAgent(Walleted, Agent, Caching):
                 self._getIssuerWalletContextDir())
             if restoredWallet:
                 self.issuer.restorePersistedWallet(restoredWallet)
-                self.logger.info('Saved keyring "issuer" restored ({})'.
+                self.logger.info('Saved wallet "issuer" restored ({})'.
                              format(walletFilePath))
 
     def _restoreLastActiveWallet(self, contextDir):
@@ -164,7 +164,7 @@ class WalletedAgent(Walleted, Agent, Caching):
                     format(walletFilePath, e))
         except IOError as exc:
             if exc.errno == errno.ENOENT:
-                self.logger.debug("no such keyring file exists ({})".
+                self.logger.debug("no such wallet file exists ({})".
                               format(walletFilePath))
             else:
                 raise exc

--- a/sovrin_client/agent/walleted_agent.py
+++ b/sovrin_client/agent/walleted_agent.py
@@ -75,9 +75,9 @@ class WalletedAgent(Walleted, Agent, Caching):
     def walletSaver(self):
         if self._walletSaver is None:
             self._walletSaver = WalletStorageHelper(
-                    self.getKeyringsBaseDir(),
-                    dmode=self.config.KEYRING_DIR_MODE,
-                    fmode=self.config.KEYRING_FILE_MODE)
+                    self.getWalletsBaseDir(),
+                    dmode=self.config.WALLET_DIR_MODE,
+                    fmode=self.config.WALLET_FILE_MODE)
         return self._walletSaver
 
     @Agent.client.setter
@@ -93,13 +93,13 @@ class WalletedAgent(Walleted, Agent, Caching):
         self._saveAllWallets()
         super().stop(*args, **kwargs)
 
-    def getKeyringsBaseDir(self):
+    def getWalletsBaseDir(self):
         return os.path.expanduser(os.path.join(
-            self.config.baseDir, self.config.keyringsDir))
+            self.config.baseDir, self.config.walletsDir))
 
     def getContextDir(self):
         return os.path.join(
-            self.getKeyringsBaseDir(),
+            self.getWalletsBaseDir(),
             "agents", self.name.lower().replace(" ", "-"))
 
     def _getIssuerWalletContextDir(self):

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -1554,7 +1554,7 @@ class SovrinCli(PlenumCli):
             return True
 
     def _listLinks(self, matchedVars):
-        if matchedVars.get('list_links') == listLinksCmd.id:
+        if matchedVars.get('list_connections') == listLinksCmd.id:
             links = self.activeWallet.getLinkNames()
             if len(links) == 0:
                 self.print("No connections exists")

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -1557,7 +1557,7 @@ class SovrinCli(PlenumCli):
         if matchedVars.get('list_links') == listLinksCmd.id:
             links = self.activeWallet.getLinkNames()
             if len(links) == 0:
-                self.print("No links exists")
+                self.print("No connections exists")
             else:
                 for link in links:
                     self.print(link + "\n")
@@ -1839,15 +1839,15 @@ class SovrinCli(PlenumCli):
                        "or an IoT-style thing")
 
         def loadHelper():
-            self.print("Creates the link, generates DID and signing keys")
+            self.print("Creates the connection, generates DID and signing keys")
             self.printUsage(self._getLoadFileUsage("<request filename>"))
 
         def showHelper():
-            self.print("Shows the info about the link request")
+            self.print("Shows the info about the link connection")
             self.printUsage(self._getShowFileUsage("<request filename>"))
 
         def showLinkHelper():
-            self.print("Shows link info in case of one matching link, "
+            self.print("Shows connection info in case of one matching link, "
                        "otherwise shows all the matching links")
             self.printUsage(self._getShowLinkUsage())
 

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -1661,7 +1661,7 @@ class SovrinCli(PlenumCli):
                 self.print("    new location: {}".format(
                     targetWalletFilePath), Token.BoldBlue)
                 if randomSuffix != '':
-                    self.print("    new keyring name: {}".format(
+                    self.print("    new wallet name: {}".format(
                         self._activeWallet.name), Token.BoldBlue)
                     self.print("    Note:\n       Target environment "
                                "already had a keyring with name '{}', so we "

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -1915,6 +1915,7 @@ class SovrinCli(PlenumCli):
         mappings['listLinks'] = listLinksCmd
         mappings['reqClaim'] = reqClaimCmd
         mappings['showProofRequest'] = showProofRequestCmd
+        mappings['acceptInvitationLink'] = acceptLinkCmd
         mappings['addGenTxnAction'] = addGenesisTxnCmd
         mappings['setAttr'] = setAttrCmd
         mappings['sendProofRequest'] = sendProofRequestCmd

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -1915,7 +1915,6 @@ class SovrinCli(PlenumCli):
         mappings['listLinks'] = listLinksCmd
         mappings['reqClaim'] = reqClaimCmd
         mappings['showProofRequest'] = showProofRequestCmd
-        mappings['acceptInvitationLink'] = acceptLinkCmd
         mappings['addGenTxnAction'] = addGenesisTxnCmd
         mappings['setAttr'] = setAttrCmd
         mappings['sendProofRequest'] = sendProofRequestCmd

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -681,7 +681,7 @@ class SovrinCli(PlenumCli):
                     "Pool upgrade failed: {}".format(error),
                     Token.BoldOrange)
             else:
-                self.print("Pool upgrade successful", Token.BoldBlue)
+                self.print("Pool Upgrade Transaction Scheduled", Token.BoldBlue)
 
         self.looper.loop.call_later(.2, self._ensureReqCompleted,
                                     req.key, self.activeClient, out)

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -178,7 +178,7 @@ class SovrinCli(PlenumCli):
         completers["conn"] = WordCompleter([connectToCmd.id])
         completers["disconn"] = WordCompleter([disconnectCmd.id])
         completers["env_name"] = WordCompleter(list(self.config.ENVS.keys()))
-        completers["sync_link"] = WordCompleter([syncLinkCmd.id])
+        completers["sync_connection"] = WordCompleter([syncLinkCmd.id])
         completers["ping_target"] = WordCompleter([pingTargetCmd.id])
         completers["show_claim"] = PhraseWordCompleter(showClaimCmd.id)
         completers["req_claim"] = PhraseWordCompleter(reqClaimCmd.id)
@@ -1109,7 +1109,7 @@ class SovrinCli(PlenumCli):
             return True
 
     def _syncLink(self, matchedVars):
-        if matchedVars.get('sync_link') == syncLinkCmd.id:
+        if matchedVars.get('sync_connection') == syncLinkCmd.id:
             # TODO: Shouldn't we remove single quotes too?
             linkName = SovrinCli.removeSpecialChars(matchedVars.get('link_name'))
             self._syncLinkInvitation(linkName)

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -138,7 +138,7 @@ class SovrinCli(PlenumCli):
             'conn',
             'disconn',
             'load_file',
-            'show_link',
+            'show_connection',
             'sync_link',
             'ping_target'
             'show_claim',
@@ -174,7 +174,7 @@ class SovrinCli(PlenumCli):
             addGenesisTxnCmd.id)
         completers["show_file"] = WordCompleter([showFileCmd.id])
         completers["load_file"] = WordCompleter([loadFileCmd.id])
-        completers["show_link"] = PhraseWordCompleter(showLinkCmd.id)
+        completers["show_connection"] = PhraseWordCompleter(showLinkCmd.id)
         completers["conn"] = WordCompleter([connectToCmd.id])
         completers["disconn"] = WordCompleter([disconnectCmd.id])
         completers["env_name"] = WordCompleter(list(self.config.ENVS.keys()))
@@ -1082,7 +1082,7 @@ class SovrinCli(PlenumCli):
         self.printSuggestion(msgs)
 
     def _printNoLinkFoundMsg(self):
-        self.print("No matching link invitations found in current wallet")
+        self.print("No matching connection invitations found in current wallet")
         self._printShowAndLoadFileSuggestion()
 
     def _isConnectedToAnyEnv(self):
@@ -1147,7 +1147,7 @@ class SovrinCli(PlenumCli):
         self._printShowAndAcceptLinkUsage()
 
     def _showLink(self, matchedVars):
-        if matchedVars.get('show_link') == showLinkCmd.id:
+        if matchedVars.get('show_connection') == showLinkCmd.id:
             linkName = matchedVars.get('link_name').replace('"', '')
 
             totalFound, exactlyMatchedLinks, likelyMatchedLinks = \
@@ -1867,7 +1867,7 @@ class SovrinCli(PlenumCli):
             'prompt': promptHelper,
             'principals': principalsHelper,
             'load': loadHelper,
-            'show link': showLinkHelper,
+            'show connection': showLinkHelper,
             'connect': connectHelper,
             'sync': syncHelper
         }

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -139,11 +139,11 @@ class SovrinCli(PlenumCli):
             'disconn',
             'load_file',
             'show_connection',
-            'sync_link',
+            'sync_connection',
             'ping_target'
             'show_claim',
             'list_claims',
-            'list_links',
+            'list_connections',
             # 'show_claim_req',
             'show_proof_req',
             'req_claim',
@@ -186,7 +186,7 @@ class SovrinCli(PlenumCli):
         completers["set_attr"] = WordCompleter([setAttrCmd.id])
         completers["new_id"] = PhraseWordCompleter(newIdentifierCmd.id)
         completers["list_claims"] = PhraseWordCompleter(listClaimsCmd.id)
-        completers["list_links"] = PhraseWordCompleter(listLinksCmd.id)
+        completers["list_connections"] = PhraseWordCompleter(listLinksCmd.id)
         completers["show_proof_req"] = PhraseWordCompleter(
             showProofRequestCmd.id)
         completers["send_proof_request"] = PhraseWordCompleter(
@@ -1915,7 +1915,6 @@ class SovrinCli(PlenumCli):
         mappings['listLinks'] = listLinksCmd
         mappings['reqClaim'] = reqClaimCmd
         mappings['showProofRequest'] = showProofRequestCmd
-        mappings['acceptInvitationLink'] = acceptLinkCmd
         mappings['addGenTxnAction'] = addGenesisTxnCmd
         mappings['setAttr'] = setAttrCmd
         mappings['sendProofRequest'] = sendProofRequestCmd

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -976,7 +976,7 @@ class SovrinCli(PlenumCli):
 
     def _getTargetEndpoint(self, li, postSync):
         if not self.activeWallet.identifiers:
-            self.print("No key present in keyring for making request on Sovrin,"
+            self.print("No key present in wallet for making request on Sovrin,"
                        " so adding one")
             self._newSigner(wallet=self.activeWallet)
         if self._isConnectedToAnyEnv():
@@ -1082,7 +1082,7 @@ class SovrinCli(PlenumCli):
         self.printSuggestion(msgs)
 
     def _printNoLinkFoundMsg(self):
-        self.print("No matching link invitations found in current keyring")
+        self.print("No matching link invitations found in current wallet")
         self._printShowAndLoadFileSuggestion()
 
     def _isConnectedToAnyEnv(self):
@@ -1176,14 +1176,14 @@ class SovrinCli(PlenumCli):
             return True
 
     # def _printNoClaimReqFoundMsg(self):
-    #     self.print("No matching Claim Requests found in current keyring\n")
+    #     self.print("No matching Claim Requests found in current wallet\n")
     #
     def _printNoProofReqFoundMsg(self):
-        self.print("No matching Proof Requests found in current keyring\n")
+        self.print("No matching Proof Requests found in current wallet\n")
 
     def _printNoClaimFoundMsg(self):
         self.print("No matching Claims found in "
-                   "any links in current keyring\n")
+                   "any links in current wallet\n")
 
     def _printMoreThanOneLinkFoundForRequest(self, requestedName, linkNames):
         self.print('More than one link matches "{}"'.format(requestedName))
@@ -1308,7 +1308,7 @@ class SovrinCli(PlenumCli):
 
         id, signer = self.activeWallet.addIdentifier(identifier,
                                                      seed=cseed, alias=alias)
-        self.print("Identifier created in keyring {}".format(self.activeWallet))
+        self.print("Identifier created in wallet {}".format(self.activeWallet))
         self.print("New identifier is {}".format(signer.identifier))
         self.print("New verification key is {}".format(signer.verkey))
         self._setActiveIdentifier(id)
@@ -1406,7 +1406,7 @@ class SovrinCli(PlenumCli):
             return rcvdClaim
         else:
             self.print("No matching Claims found "
-                       "in any links in current keyring")
+                       "in any links in current wallet")
 
     def _printRequestClaimMsg(self, claimName):
         self.printSuggestion(self._getReqClaimUsage(claimName))
@@ -1623,7 +1623,7 @@ class SovrinCli(PlenumCli):
         if self._activeWallet:
             if not self.checkIfWalletBelongsToCurrentContext(self._activeWallet):
                 self.print(self.getWalletContextMistmatchMsg, Token.BoldOrange)
-                self.print("Any changes made to this keyring won't "
+                self.print("Any changes made to this wallet won't "
                            "be persisted.", Token.BoldOrange)
 
     def moveActiveWalletToNewContext(self, newEnv):
@@ -1651,10 +1651,10 @@ class SovrinCli(PlenumCli):
                 targetWalletFilePath = getWalletFilePath(
                     targetContextDir, self.walletFileName)
 
-                self.print("Current active keyring got moved to '{}' "
+                self.print("Current active wallet got moved to '{}' "
                            "environment. Here is the detail:".format(newEnv),
                            Token.BoldBlue)
-                self.print("    keyring name: {}".format(
+                self.print("    wallet name: {}".format(
                     currentWalletName), Token.BoldBlue)
                 self.print("    old location: {}".format(
                     sourceWalletFilePath), Token.BoldBlue)
@@ -1664,10 +1664,10 @@ class SovrinCli(PlenumCli):
                     self.print("    new wallet name: {}".format(
                         self._activeWallet.name), Token.BoldBlue)
                     self.print("    Note:\n       Target environment "
-                               "already had a keyring with name '{}', so we "
-                               "renamed current active keyring to '{}'.\n      "
-                               " You can always rename any keyring with more "
-                               "meaningful name with 'rename keyring' command.".
+                               "already had a wallet with name '{}', so we "
+                               "renamed current active wallet to '{}'.\n      "
+                               " You can always rename any wallet with more "
+                               "meaningful name with 'rename wallet' command.".
                                format(currentWalletName, self._activeWallet.name),
                                Token.BoldBlue)
                 self._activeWallet = None
@@ -1742,7 +1742,7 @@ class SovrinCli(PlenumCli):
                 else NO_ENV
 
     def getStatus(self):
-        # TODO: This needs to show active keyring and active identifier
+        # TODO: This needs to show active wallet and active identifier
         if not self.activeEnv:
             self._printNotConnectedEnvMessage()
         else:

--- a/sovrin_client/cli/cli.py
+++ b/sovrin_client/cli/cli.py
@@ -1633,8 +1633,8 @@ class SovrinCli(PlenumCli):
                 self._activeWallet.env = newEnv
                 randomSuffix = ''
                 sourceWalletFilePath = getWalletFilePath(
-                    self.getContextBasedKeyringsBaseDir(), self.walletFileName)
-                targetContextDir = os.path.join(self.getKeyringsBaseDir(),
+                    self.getContextBasedWalletsBaseDir(), self.walletFileName)
+                targetContextDir = os.path.join(self.getWalletsBaseDir(),
                                                 newEnv)
                 if os.path.exists(sourceWalletFilePath):
                     while True:

--- a/sovrin_client/cli/command.py
+++ b/sovrin_client/cli/command.py
@@ -109,10 +109,10 @@ loadFileCmd = Command(
     examples="load sample/faber-invitation.sovrin")
 
 showLinkCmd = Command(
-    id="show link",
-    title="Shows link info in case of one matching link, otherwise shows all the matching link names",
-    usage="show link <link-name>",
-    examples="show link faber")
+    id="show connection",
+    title="Shows connection info in case of one matching connection, otherwise shows all the matching connection names",
+    usage="show connection <connection-name>",
+    examples="show connection faber")
 
 connectToCmd = Command(
     id="connect",

--- a/sovrin_client/cli/command.py
+++ b/sovrin_client/cli/command.py
@@ -127,9 +127,9 @@ disconnectCmd = Command(
 
 syncLinkCmd = Command(
     id="sync",
-    title="Synchronizes the link between the endpoints",
-    usage="sync link <link-name>",
-    examples="sync link faber")
+    title="Synchronizes the connection between the endpoints",
+    usage="sync connection <connection-name>",
+    examples="sync connection faber")
 
 pingTargetCmd = Command(
     id="ping",

--- a/sovrin_client/cli/command.py
+++ b/sovrin_client/cli/command.py
@@ -15,8 +15,8 @@ getClaimDefName = SovrinTransactions.GET_CLAIM_DEF.name
 
 sendNymCmd = Command(
     id="send {nym}".format(nym=nymName),
-    title="Adds given identifier to sovrin",
-    usage="send {nym} dest=<target identifier> role=<role> [verkey=<ver-key>]".format(nym=nymName),
+    title="Adds given DID to sovrin",
+    usage="send {nym} dest=<target DID> role=<role> [verkey=<ver-key>]".format(nym=nymName),
     examples=[
         "send {nym} dest=BiCMHDqC5EjheFHumZX9nuAoVEp8xyuBgiRi5JcY5whi role={role}".format(nym=nymName,
                                                                                           role=Roles.TRUST_ANCHOR.name),
@@ -25,26 +25,26 @@ sendNymCmd = Command(
 sendGetNymCmd = Command(
     id="send {getNym}".format(getNym=getNymName),
     title="Get NYM from sovrin",
-    usage="send {getNym} dest=<target identifier>".format(getNym=getNymName),
+    usage="send {getNym} dest=<target DID>".format(getNym=getNymName),
     examples="send {getNym} dest=33A18XMqWqTzDpLHXLR5nT".format(getNym=getNymName))
 
 sendAttribCmd = Command(
     id="send {attrib}".format(attrib=attribName),
-    title="Adds attributes to existing identifier",
-    usage="send {attrib} dest=<target identifier> [raw={{<json-data>}}] [hash=<hashed-data>] [enc: <encrypted-data>]".format(
+    title="Adds attributes to existing DID",
+    usage="send {attrib} dest=<target DID> [raw={{<json-data>}}] [hash=<hashed-data>] [enc: <encrypted-data>]".format(
         attrib=attribName),
     examples='send {attrib} dest=33A18XMqWqTzDpLHXLR5nT raw={{"endpoint": "127.0.0.1:5555"}}'.format(attrib=attribName))
 
 sendGetAttrCmd = Command(
     id="send {getAttr}".format(getAttr=getAttrName),
     title="Get ATTR from sovrin",
-    usage="send {getAttr} dest=<target identifier>".format(getAttr=getAttrName),
+    usage="send {getAttr} dest=<target DID>".format(getAttr=getAttrName),
     examples="send {getAttr} dest=33A18XMqWqTzDpLHXLR5nT".format(getAttr=getAttrName))
 
 sendNodeCmd = Command(
     id="send {node}".format(node=nodeName),
     title="Adds a node to the pool",
-    usage="send {node} dest=<target node identifier> data={{<json-data>}}".format(node=nodeName),
+    usage="send {node} dest=<target node DID> data={{<json-data>}}".format(node=nodeName),
     note="Only Steward (must be already added on sovrin) can execute this command to add new node to the pool",
     examples='send {node} dest=87Ys5T2eZfau4AATsBZAYvqwvD8XL5xYCHgg2o1ffjqg data={{"services":["VALIDATOR"], "node_ip": "127.0.0.1", "node_port": 9711, "client_ip": "127.0.0.1", "client_port": 9712, "alias": "Node101"}}'.format(
         node=nodeName))
@@ -75,7 +75,7 @@ sendSchemaCmd = Command(
 sendGetSchemaCmd = Command(
     id="send {getSchema}".format(getSchema=getSchemaName),
     title="Gets schema from sovrin",
-    usage="send {getSchema} dest=<target identifier> name=<schema-name> version=<version>".format(getSchema=getSchemaName),
+    usage="send {getSchema} dest=<target DID> name=<schema-name> version=<version>".format(getSchema=getSchemaName),
     examples="send {getSchema} name=Degree version=1.0".format(getSchema=getSchemaName))
 
 sendClaimDefCmd = Command(
@@ -169,10 +169,10 @@ showProofRequestCmd = Command(
     examples="show proof request Transcription")
 
 acceptLinkCmd = Command(
-    id="accept invitation from",
-    title="Accept invitation from given remote",
-    usage="accept invitation from <remote>",
-    examples="accept invitation from Faber")
+    id="accept request from",
+    title="Accept request from given remote",
+    usage="accept request from <remote>",
+    examples="accept request from Faber")
 
 setAttrCmd = Command(
     id="set",
@@ -189,7 +189,7 @@ sendProofCmd = Command(
 addGenesisTxnCmd = Command(
     id="add genesis transaction",
     title="Adds given genesis transaction",
-    usage="add genesis transaction {nym} dest=<dest-identifier> [role=<role>]".format(nym=nymName),
+    usage="add genesis transaction {nym} dest=<dest-DID> [role=<role>]".format(nym=nymName),
     examples=[
         'add genesis transaction {nym} dest=2ru5PcgeQzxF7QZYwQgDkG2K13PRqyigVw99zMYg8eML'.format(nym=nymName),
         'add genesis transaction {nym} dest=2ru5PcgeQzxF7QZYwQgDkG2K13PRqyigVw99zMYg8eML role={role}'.format(
@@ -198,17 +198,17 @@ addGenesisTxnCmd = Command(
         '{{"node_ip": "localhost", "node_port": "9701", "client_ip": "localhost", "client_port": "9702", "alias": "AliceNode"}}'.format(node=nodeName)])
 
 newIdentifierCmd = Command(
-    id="new identifier",
-    title="Creates new Identifier",
-    usage="new identifier [<identifier>|abbr|crypto] [with seed <seed>] [as <alias>]",
-    note="crypto = cryptographic identifier, abbr = abbreviated verkey",
+    id="new DID",
+    title="Creates new DID",
+    usage="new DID [<DID>|abbr|crypto] [with seed <seed>] [as <alias>]",
+    note="crypto = cryptographic DID, abbr = abbreviated verkey",
     examples=[
-        "new identifier",
-        "new identifier abbr",
-        "new identifier 4QxzWk3ajdnEA37NdNU5Kt",
-        "new identifier with seed aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "new identifier abbr with seed aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "new identifier 4QxzWk3ajdnEA37NdNU5Kt with seed aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"])
+        "new DID",
+        "new DID abbr",
+        "new DID 4QxzWk3ajdnEA37NdNU5Kt",
+        "new DID with seed aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "new DID abbr with seed aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "new DID 4QxzWk3ajdnEA37NdNU5Kt with seed aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"])
 
 reqAvailClaimsCmd = Command(
     id="request available claims from",

--- a/sovrin_client/cli/command.py
+++ b/sovrin_client/cli/command.py
@@ -150,10 +150,10 @@ listClaimsCmd = Command(
     examples="list claims faber")
 
 listLinksCmd = Command(
-    id='list links',
-    title='List available links in active wallet',
-    usage='list links',
-    examples='list links'
+    id='list connections',
+    title='List available connections in active wallet',
+    usage='list connections',
+    examples='list connections'
 )
 
 reqClaimCmd = Command(

--- a/sovrin_client/cli/command.py
+++ b/sovrin_client/cli/command.py
@@ -104,7 +104,7 @@ showFileCmd = Command(
 
 loadFileCmd = Command(
     id="load",
-    title="Creates the link",
+    title="Creates the connection",
     usage="load <file-path>",
     examples="load sample/faber-invitation.sovrin")
 

--- a/sovrin_client/cli/constants.py
+++ b/sovrin_client/cli/constants.py
@@ -96,7 +96,7 @@ DISCONNECT_REG_EX = "(\s*(?P<disconn>disconnect))"
 LOAD_FILE_REG_EX = "(\s*(?P<load_file>load) " \
                    "\s+ (?P<file_path>[A-Za-z0-9+-.=/]+)\s*)"
 
-SHOW_LINK_REG_EX = '(\s*(?P<show_link>show \s+ link) ' \
+SHOW_LINK_REG_EX = '(\s*(?P<show_connection>show \s+ connection) ' \
                    '\s+ (?P<link_name>[A-Za-z0-9-." ]+) \s*)'
 
 SYNC_LINK_REG_EX = '(\s*(?P<sync_link>sync) ' \

--- a/sovrin_client/cli/constants.py
+++ b/sovrin_client/cli/constants.py
@@ -5,7 +5,7 @@ from sovrin_common.transactions import SovrinTransactions
 
 CLIENT_GRAMS_CLIENT_WITH_IDENTIFIER_FORMATTED_REG_EX = getPipedRegEx(
     CLIENT_GRAMS_CLIENT_COMMAND_REG_EX +
-    "\s+ (?P<with_identifier>with\s+identifier) "
+    "\s+ (?P<with_DID>with\s+DID) "
     "\s+ (?P<nym>[a-zA-Z0-9=]+) \s*") \
     .format(relist(CLI_CMDS))
 
@@ -32,7 +32,7 @@ SEND_NYM_REG_EX = TXN_NYM.format(cmdName='send_nym', cmd='send')
 ADD_GENESIS_NYM_REG_EX = TXN_NYM.format(cmdName='add_genesis',
                                         cmd='add \s+ genesis \s+ transaction')
 
-NEW_ID_REG_EX = "(\s* (?P<new_id>new\s+identifier)" \
+NEW_ID_REG_EX = "(\s* (?P<new_id>new\s+DID)" \
                 "\s? (?P<id>([A-Za-z0-9+=/]+))? " \
                 "\s? (with\s+seed\s+(?P<seed>[a-zA-Z0-9]+))? " \
                 "\s? (as\s+(?P<alias>[a-zA-Z0-9-]+))?)"
@@ -106,7 +106,7 @@ PING_TARGET_REG_EX = '(\s*(?P<ping>ping) ' \
                      '\s+ (?P<target_name>[A-Za-z0-9-." ]+) \s*)'
 
 ACCEPT_LINK_REG_EX = \
-    '(\s*(?P<accept_link_invite>accept \s+ invitation \s+ from) ' \
+    '(\s*(?P<accept_connection_request>accept \s+ request \s+ from) ' \
     '\s+ (?P<link_name>[A-Za-z0-9-." ]+) \s*)'
 
 SHOW_CLAIM_REG_EX = '(\s*(?P<show_claim>show \s+ claim) ' \

--- a/sovrin_client/cli/constants.py
+++ b/sovrin_client/cli/constants.py
@@ -99,7 +99,7 @@ LOAD_FILE_REG_EX = "(\s*(?P<load_file>load) " \
 SHOW_LINK_REG_EX = '(\s*(?P<show_connection>show \s+ connection) ' \
                    '\s+ (?P<link_name>[A-Za-z0-9-." ]+) \s*)'
 
-SYNC_LINK_REG_EX = '(\s*(?P<sync_link>sync) ' \
+SYNC_LINK_REG_EX = '(\s*(?P<sync_connection>sync) ' \
                    '\s+ (?P<link_name>[A-Za-z0-9-." ]+) \s*)'
 
 PING_TARGET_REG_EX = '(\s*(?P<ping>ping) ' \

--- a/sovrin_client/cli/constants.py
+++ b/sovrin_client/cli/constants.py
@@ -116,7 +116,7 @@ SHOW_CLAIM_REG_EX = '(\s*(?P<show_claim>show \s+ claim) ' \
 LIST_CLAIMS_REG_EX = '(\s*(?P<list_claims>list \s+ claims) ' \
                      '\s+ (?P<link_name>[A-Za-z0-9-." ]+) \s*)'
 
-LIST_LINKS_REG_EX = '(\s*(?P<list_links>list \s+ links))'
+LIST_LINKS_REG_EX = '(\s*(?P<list_connections>list \s+ connections))'
 
 REQUEST_CLAIM_REG_EX = '(\s*(?P<req_claim>request \s+ claim) ' \
                        '\s+ (?P<claim_name>[A-Za-z0-9-." ]+) ' \

--- a/sovrin_client/client/wallet/link.py
+++ b/sovrin_client/client/wallet/link.py
@@ -32,7 +32,7 @@ class constant:
     LINK_LAST_SEQ_NO = "Last Sync no"
     LINK_STATUS_ACCEPTED = "Accepted"
 
-    LINK_NOT_SYNCHRONIZED = "<this link has not yet been synchronized>"
+    LINK_NOT_SYNCHRONIZED = "<this connection has not yet been synchronized>"
     UNKNOWN_WAITING_FOR_SYNC = "<unknown, waiting for sync>"
 
     LINK_ITEM_PREFIX = '\n    '
@@ -130,7 +130,7 @@ class Link:
         # TODO: This should be set as verkey in case of DID but need it from
         # wallet
         verKey = self.localVerkey if self.localVerkey else constant.SIGNER_VER_KEY_EMPTY
-        fixedLinkHeading = "Link"
+        fixedLinkHeading = "Connection"
         if not self.isAccepted:
             fixedLinkHeading += " (not yet accepted)"
 
@@ -139,7 +139,7 @@ class Link:
         fixedLinkItems = \
             '\n' \
             'Name: ' + self.name + '\n' \
-            'Identifier: ' + localIdr + '\n' \
+            'DID: ' + localIdr + '\n' \
             'Trust anchor: ' + trustAnchor + ' ' + trustAnchorStatus + '\n' \
             'Verification key: ' + verKey + '\n' \
             'Signing key: <hidden>' '\n' \
@@ -147,8 +147,8 @@ class Link:
                           constant.UNKNOWN_WAITING_FOR_SYNC) + '\n' \
             'Remote Verification key: ' + remoteVerKey + '\n' \
             'Remote endpoint: ' + remoteEndPoint + '\n' \
-            'Invitation nonce: ' + self.invitationNonce + '\n' \
-            'Invitation status: ' + linkStatus + '\n'
+            'Request nonce: ' + self.invitationNonce + '\n' \
+            'Request status: ' + linkStatus + '\n'
 
         optionalLinkItems = ""
         if len(self.proofRequests) > 0:

--- a/sovrin_client/test/cli/conftest.py
+++ b/sovrin_client/test/cli/conftest.py
@@ -1315,7 +1315,7 @@ def philCli(be, do, philCLI, trusteeCli, poolTxnData):
 
     do('prompt Phil', expect=prompt_is('Phil'))
 
-    do('new keyring Phil', expect=['New keyring Phil created',
+    do('new wallet Phil', expect=['New keyring Phil created',
                                    'Active keyring set to "Phil"'])
     phil_seed = poolTxnData['seeds']['Steward1']
     phil_signer = DidSigner(seed=phil_seed.encode())

--- a/sovrin_client/test/cli/conftest.py
+++ b/sovrin_client/test/cli/conftest.py
@@ -1315,8 +1315,8 @@ def philCli(be, do, philCLI, trusteeCli, poolTxnData):
 
     do('prompt Phil', expect=prompt_is('Phil'))
 
-    do('new wallet Phil', expect=['New keyring Phil created',
-                                   'Active keyring set to "Phil"'])
+    do('new wallet Phil', expect=['New wallet Phil created',
+                                   'Active wallet set to "Phil"'])
     phil_seed = poolTxnData['seeds']['Steward1']
     phil_signer = DidSigner(seed=phil_seed.encode())
 

--- a/sovrin_client/test/cli/conftest.py
+++ b/sovrin_client/test/cli/conftest.py
@@ -199,7 +199,7 @@ def loadInviteOut(nextCommandsToTryUsageLine):
             "Creating Link for {inviter}.",
             ''] + \
            nextCommandsToTryUsageLine + \
-           ['    show link "{inviter}"',
+           ['    show connection "{inviter}"',
             '    accept invitation from "{inviter}"',
             '',
             '']
@@ -450,7 +450,7 @@ def proofRequestNotExists():
 
 @pytest.fixture(scope="module")
 def linkNotExists():
-    return ["No matching link invitations found in current wallet"]
+    return ["No matching connection invitations found in current wallet"]
 
 
 @pytest.fixture(scope="module")

--- a/sovrin_client/test/cli/conftest.py
+++ b/sovrin_client/test/cli/conftest.py
@@ -195,12 +195,12 @@ def thriftMap(agentIpAddress, thriftAgentPort):
 
 @pytest.fixture(scope="module")
 def loadInviteOut(nextCommandsToTryUsageLine):
-    return ["1 link invitation found for {inviter}.",
-            "Creating Link for {inviter}.",
+    return ["1 connection request found for {inviter}.",
+            "Creating connection for {inviter}.",
             ''] + \
            nextCommandsToTryUsageLine + \
            ['    show connection "{inviter}"',
-            '    accept invitation from "{inviter}"',
+            '    accept request from "{inviter}"',
             '',
             '']
 
@@ -244,8 +244,8 @@ def acceptUnSyncedWithoutEndpointWhenConnected(
 
 @pytest.fixture(scope="module")
 def commonAcceptInvitationMsgs():
-    return ["Invitation not yet verified",
-            "Link not yet synchronized.",
+    return ["Request not yet verified",
+            "Connection not yet synchronized.",
             ]
 
 
@@ -253,7 +253,7 @@ def commonAcceptInvitationMsgs():
 def acceptUnSyncedWhenNotConnected(commonAcceptInvitationMsgs,
                                    canNotSyncMsg, connectUsage):
     return commonAcceptInvitationMsgs + \
-            ["Invitation acceptance aborted."] + \
+            ["Request acceptance aborted."] + \
             canNotSyncMsg + connectUsage
 
 
@@ -288,7 +288,7 @@ def newKeyringOut():
 
 @pytest.fixture(scope="module")
 def linkAlreadyExists():
-    return ["Link already exists"]
+    return ["Connection already exists"]
 
 
 @pytest.fixture(scope="module")
@@ -309,9 +309,9 @@ def unsyncedInviteAcceptedWhenNotConnected(availableClaims):
     return [
         "Response from {inviter}",
         "Trust established.",
-        "Identifier created in Sovrin."
+        "DID created in Sovrin."
     ] + availableClaims + [
-        "Cannot check if identifier is written to Sovrin."
+        "Cannot check if DID is written to Sovrin."
     ]
 
 
@@ -320,9 +320,9 @@ def syncedInviteAcceptedOutWithoutClaims():
     return [
         "Signature accepted.",
         "Trust established.",
-        "Identifier created in Sovrin.",
+        "DID created in Sovrin.",
         "Synchronizing...",
-        "Confirmed identifier written to Sovrin."
+        "Confirmed DID written to Sovrin."
     ]
 
 
@@ -340,17 +340,17 @@ def syncedInviteAcceptedWithClaimsOut(
 @pytest.fixture(scope="module")
 def unsycedAcceptedInviteWithoutClaimOut(syncedInviteAcceptedOutWithoutClaims):
     return [
-        "Invitation not yet verified",
+        "Request not yet verified",
         "Attempting to sync...",
         "Synchronizing...",
     ] + syncedInviteAcceptedOutWithoutClaims + \
-           ["Confirmed identifier written to Sovrin."]
+           ["Confirmed DID written to Sovrin."]
 
 
 @pytest.fixture(scope="module")
 def unsycedAlreadyAcceptedInviteAcceptedOut():
     return [
-        "Invitation not yet verified",
+        "Request not yet verified",
         "Attempting to sync...",
         "Synchronizing..."
     ]
@@ -450,7 +450,7 @@ def proofRequestNotExists():
 
 @pytest.fixture(scope="module")
 def linkNotExists():
-    return ["No matching connection invitations found in current wallet"]
+    return ["No matching connection requests found in current wallet"]
 
 
 @pytest.fixture(scope="module")
@@ -497,7 +497,7 @@ def endpointNotAvailable():
 
 @pytest.fixture(scope="module")
 def syncLinkOutEndsWith():
-    return ["Link {inviter} synced"]
+    return ["Connection {inviter} synced"]
 
 
 @pytest.fixture(scope="module")
@@ -534,12 +534,12 @@ def linkNotYetSynced():
 
 @pytest.fixture(scope="module")
 def acceptedLinkHeading():
-    return ["Link"]
+    return ["Connection"]
 
 
 @pytest.fixture(scope="module")
 def unAcceptedLinkHeading():
-    return ["Link (not yet accepted)"]
+    return ["Connection (not yet accepted)"]
 
 
 @pytest.fixture(scope="module")
@@ -549,7 +549,7 @@ def showUnSyncedLinkOut(unAcceptedLinkHeading, showLinkOut):
 
 @pytest.fixture(scope="module")
 def showClaimNotFoundOut():
-    return ["No matching Claims found in any links in current wallet"]
+    return ["No matching Claims found in any connections in current wallet"]
 
 
 @pytest.fixture(scope="module")
@@ -646,14 +646,14 @@ def jobCertificateClaimMap():
 
 @pytest.fixture(scope="module")
 def reqClaimOut():
-    return ["Found claim {name} in link {inviter}",
+    return ["Found claim {name} in connection {inviter}",
             "Requesting claim {name} from {inviter}..."]
 
 
 # TODO Change name
 @pytest.fixture(scope="module")
 def reqClaimOut1():
-    return ["Found claim {name} in link {inviter}",
+    return ["Found claim {name} in connection {inviter}",
             "Requesting claim {name} from {inviter}...",
             "Signature accepted.",
             'Received claim "{name}".']
@@ -661,7 +661,7 @@ def reqClaimOut1():
 
 @pytest.fixture(scope="module")
 def rcvdTranscriptClaimOut():
-    return ["Found claim {name} in link {inviter}",
+    return ["Found claim {name} in connection {inviter}",
             "Name: {name}",
             "Status: ",
             "Version: {version}",
@@ -676,7 +676,7 @@ def rcvdTranscriptClaimOut():
 
 @pytest.fixture(scope="module")
 def rcvdBankingRelationshipClaimOut():
-    return ["Found claim {name} in link {inviter}",
+    return ["Found claim {name} in connection {inviter}",
             "Name: {name}",
             "Status: ",
             "Version: {version}",
@@ -696,7 +696,7 @@ def rcvdBankingRelationshipClaimOut():
 
 @pytest.fixture(scope="module")
 def rcvdJobCertClaimOut():
-    return ["Found claim {name} in link {inviter}",
+    return ["Found claim {name} in connection {inviter}",
             "Name: {name}",
             "Status: ",
             "Version: {version}",
@@ -711,7 +711,7 @@ def rcvdJobCertClaimOut():
 
 @pytest.fixture(scope="module")
 def showTranscriptClaimOut(nextCommandsToTryUsageLine):
-    return ["Found claim {name} in link {inviter}",
+    return ["Found claim {name} in connection {inviter}",
             "Name: {name}",
             "Status: {status}",
             "Version: {version}",
@@ -727,7 +727,7 @@ def showTranscriptClaimOut(nextCommandsToTryUsageLine):
 
 @pytest.fixture(scope="module")
 def showJobCertClaimOut(nextCommandsToTryUsageLine):
-    return ["Found claim {name} in link {inviter}",
+    return ["Found claim {name} in connection {inviter}",
             "Name: {name}",
             "Status: {status}",
             "Version: {version}",
@@ -743,7 +743,7 @@ def showJobCertClaimOut(nextCommandsToTryUsageLine):
 
 @pytest.fixture(scope="module")
 def showBankingRelationshipClaimOut(nextCommandsToTryUsageLine):
-    return ["Found claim {name} in link {inviter}",
+    return ["Found claim {name} in connection {inviter}",
             "Name: {name}",
             "Status: {status}",
             "Version: {version}",
@@ -807,34 +807,34 @@ def showLinkSuggestion(nextCommandsToTryUsageLine):
 @pytest.fixture(scope="module")
 def showAcceptedLinkOut():
     return [
-            "Link",
+            "Connection",
             "Name: {inviter}",
-            "Identifier: {identifier}",
+            "DID: {identifier}",
             "Verification key: {verkey}",
             "Remote: {remote}",
             "Remote Verification key: {remote-verkey}",
             "Trust anchor: {inviter} (confirmed)",
-            "Invitation nonce: {nonce}",
-            "Invitation status: Accepted"]
+            "Request nonce: {nonce}",
+            "Request status: Accepted"]
 
 
 @pytest.fixture(scope="module")
 def showLinkOut(nextCommandsToTryUsageLine, linkNotYetSynced):
     return [
             "    Name: {inviter}",
-            "    Identifier: not yet assigned",
+            "    DID: not yet assigned",
             "    Trust anchor: {inviter} (not yet written to Sovrin)",
             "    Verification key: <empty>",
             "    Signing key: <hidden>",
             "    Remote: {remote}",
             "    Remote endpoint: {endpoint}",
-            "    Invitation nonce: {nonce}",
-            "    Invitation status: not verified, remote verkey unknown",
+            "    Request nonce: {nonce}",
+            "    Request status: not verified, remote verkey unknown",
             "    Last synced: {last_synced}"] + \
            [""] + \
            nextCommandsToTryUsageLine + \
            ['    sync "{inviter}"',
-            '    accept invitation from "{inviter}"',
+            '    accept request from "{inviter}"',
             '',
             '']
 
@@ -842,15 +842,15 @@ def showLinkOut(nextCommandsToTryUsageLine, linkNotYetSynced):
 @pytest.fixture(scope="module")
 def showAcceptedSyncedLinkOut(nextCommandsToTryUsageLine):
     return [
-            "Link",
+            "Connection",
             "Name: {inviter}",
             "Trust anchor: {inviter} (confirmed)",
             "Verification key: ~",
             "Signing key: <hidden>",
             "Remote: {remote}",
             "Remote Verification key: <same as Remote>",
-            "Invitation nonce: {nonce}",
-            "Invitation status: Accepted",
+            "Request nonce: {nonce}",
+            "Request status: Accepted",
             "Proof Request(s): {proof-requests}",
             "Available Claim(s): {claims}"] + \
            nextCommandsToTryUsageLine + \
@@ -1263,8 +1263,8 @@ def trusteeCli(be, do, trusteeMap, poolNodesStarted,
                connectedToTest, nymAddedOut, trusteeCLI):
     be(trusteeCLI)
     do('new key with seed {trusteeSeed}', expect=[
-        'Identifier for key is {trusteeIdr}',
-        'Current identifier set to {trusteeIdr}'],
+        'DID for key is {trusteeIdr}',
+        'Current DID set to {trusteeIdr}'],
        mapper=trusteeMap)
 
     if not trusteeCLI._isConnectedToAnyEnv():
@@ -1324,8 +1324,8 @@ def philCli(be, do, philCLI, trusteeCli, poolTxnData):
         'seed': phil_seed,
         'idr': phil_signer.identifier}
     do('new key with seed {seed}', expect=['Key created in wallet Phil',
-                                           'Identifier for key is {idr}',
-                                           'Current identifier set to {idr}'],
+                                           'DID for key is {idr}',
+                                           'Current DID set to {idr}'],
        mapper=mapper)
 
     addNym(be, do, trusteeCli,
@@ -1409,8 +1409,8 @@ def newStewardCli(be, do, poolNodesStarted, trusteeCli, connectedToTest,
     be(cliWithNewStewardName)
 
     do('new key with seed {newStewardSeed}', expect=[
-        'Identifier for key is {newStewardIdr}',
-        'Current identifier set to {newStewardIdr}'],
+        'DID for key is {newStewardIdr}',
+        'Current DID set to {newStewardIdr}'],
        mapper=newStewardVals)
 
     if not cliWithNewStewardName._isConnectedToAnyEnv():

--- a/sovrin_client/test/cli/conftest.py
+++ b/sovrin_client/test/cli/conftest.py
@@ -281,8 +281,8 @@ def notConnectedStatus(connectUsage):
 
 @pytest.fixture(scope="module")
 def newKeyringOut():
-    return ["New keyring {keyring-name} created",
-            'Active keyring set to "{keyring-name}"'
+    return ["New wallet {keyring-name} created",
+            'Active wallet set to "{keyring-name}"'
             ]
 
 

--- a/sovrin_client/test/cli/conftest.py
+++ b/sovrin_client/test/cli/conftest.py
@@ -445,12 +445,12 @@ def showBankingProofOut():
 
 @pytest.fixture(scope="module")
 def proofRequestNotExists():
-    return ["No matching Proof Requests found in current keyring"]
+    return ["No matching Proof Requests found in current wallet"]
 
 
 @pytest.fixture(scope="module")
 def linkNotExists():
-    return ["No matching link invitations found in current keyring"]
+    return ["No matching link invitations found in current wallet"]
 
 
 @pytest.fixture(scope="module")
@@ -549,7 +549,7 @@ def showUnSyncedLinkOut(unAcceptedLinkHeading, showLinkOut):
 
 @pytest.fixture(scope="module")
 def showClaimNotFoundOut():
-    return ["No matching Claims found in any links in current keyring"]
+    return ["No matching Claims found in any links in current wallet"]
 
 
 @pytest.fixture(scope="module")
@@ -1183,7 +1183,7 @@ def thriftIsRunning(emptyLooper, tdirWithPoolTxns, thriftWallet,
 
 @pytest.fixture(scope='module')
 def savedKeyringRestored():
-    return ['Saved keyring {keyring-name} restored']
+    return ['Saved wallet {keyring-name} restored']
 
 
 # TODO: Need to refactor following three fixture to reuse code
@@ -1323,7 +1323,7 @@ def philCli(be, do, philCLI, trusteeCli, poolTxnData):
     mapper = {
         'seed': phil_seed,
         'idr': phil_signer.identifier}
-    do('new key with seed {seed}', expect=['Key created in keyring Phil',
+    do('new key with seed {seed}', expect=['Key created in wallet Phil',
                                            'Identifier for key is {idr}',
                                            'Current identifier set to {idr}'],
        mapper=mapper)

--- a/sovrin_client/test/cli/helper.py
+++ b/sovrin_client/test/cli/helper.py
@@ -348,7 +348,7 @@ def newKey(be, do, userCli, seed=None):
     if seed is not None:
         cmd += ' with seed {}'.format(seed)
 
-    do(cmd, expect='Current identifier set to')
+    do(cmd, expect='Current DID set to')
 
 
 def getAgentCliHelpString():
@@ -359,7 +359,7 @@ def getAgentCliHelpString():
             help [<command name>]
        prompt - Changes the prompt to given principal (a person like Alice, an organization like Faber College, or an IoT-style thing)
        list wallets - Lists all wallets
-       list ids - Lists all identifiers of active wallet
+       list ids - Lists all DIDs of active wallet
        show - Shows content of given file
        show connection - Shows connection info in case of one matching connection, otherwise shows all the matching connection names
        ping - Pings given remote's endpoint

--- a/sovrin_client/test/cli/helper.py
+++ b/sovrin_client/test/cli/helper.py
@@ -358,8 +358,8 @@ def getAgentCliHelpString():
          Usage:
             help [<command name>]
        prompt - Changes the prompt to given principal (a person like Alice, an organization like Faber College, or an IoT-style thing)
-       list keyrings - Lists all keyrings
-       list ids - Lists all identifiers of active keyring
+       list wallets - Lists all wallets
+       list ids - Lists all identifiers of active wallet
        show - Shows content of given file
        show link - Shows link info in case of one matching link, otherwise shows all the matching link names
        ping - Pings given remote's endpoint

--- a/sovrin_client/test/cli/helper.py
+++ b/sovrin_client/test/cli/helper.py
@@ -361,7 +361,7 @@ def getAgentCliHelpString():
        list wallets - Lists all wallets
        list ids - Lists all identifiers of active wallet
        show - Shows content of given file
-       show link - Shows link info in case of one matching link, otherwise shows all the matching link names
+       show connection - Shows connection info in case of one matching connection, otherwise shows all the matching connection names
        ping - Pings given remote's endpoint
        list links - List available links in active wallet
        send proofreq - Send a proof request

--- a/sovrin_client/test/cli/helper.py
+++ b/sovrin_client/test/cli/helper.py
@@ -363,7 +363,7 @@ def getAgentCliHelpString():
        show - Shows content of given file
        show connection - Shows connection info in case of one matching connection, otherwise shows all the matching connection names
        ping - Pings given remote's endpoint
-       list links - List available links in active wallet
+       list connections - List available connections in active wallet
        send proofreq - Send a proof request
        license - Shows the license
        exit - Exit the command-line interface ('quit' also works)"""

--- a/sovrin_client/test/cli/test_agent_cli.py
+++ b/sovrin_client/test/cli/test_agent_cli.py
@@ -102,7 +102,7 @@ def aliceAcceptedAcmeInvitationNoProofReq(
            mapper=acmeMap,
            expect=syncLinkOutWithEndpoint,
            within=15)
-        do('accept invitation from {inviter}',
+        do('accept request from {inviter}',
            within=15,
            mapper=acmeMap,
            expect=unsycedAcceptedInviteWithoutClaimOut)

--- a/sovrin_client/test/cli/test_agent_cli.py
+++ b/sovrin_client/test/cli/test_agent_cli.py
@@ -92,7 +92,7 @@ def aliceAcceptedAcmeInvitationNoProofReq(
         keyringMapper = {
             'keyring-name': keyring
         }
-        do('new keyring {}'.format(keyring),
+        do('new wallet {}'.format(keyring),
            expect=newKeyringOut,
            mapper=keyringMapper)
         do('load {}'.format(invitationFile),

--- a/sovrin_client/test/cli/test_agent_wallet_persistence.py
+++ b/sovrin_client/test/cli/test_agent_wallet_persistence.py
@@ -50,8 +50,8 @@ def changeAndPersistWallet(agent, emptyLooper):
     agent.stop()
     emptyLooper.runFor(.5)
     assert os.path.isfile(expectedFilePath)
-    assert stat.S_IMODE(os.stat(agent.getContextDir()).st_mode) == agent.config.KEYRING_DIR_MODE
-    assert stat.S_IMODE(os.stat(expectedFilePath).st_mode) == agent.config.KEYRING_FILE_MODE
+    assert stat.S_IMODE(os.stat(agent.getContextDir()).st_mode) == agent.config.WALLET_DIR_MODE
+    assert stat.S_IMODE(os.stat(expectedFilePath).st_mode) == agent.config.WALLET_FILE_MODE
     return walletToBePersisted
 
 

--- a/sovrin_client/test/cli/test_cli_exit.py
+++ b/sovrin_client/test/cli/test_cli_exit.py
@@ -12,7 +12,7 @@ def testCliExitCommand(be, do, poolNodesStarted, aliceCLI, CliBuilder,
     name = 'Alice'
     be(aliceCLI)
     do('prompt {}'.format(name), expect=prompt_is(name))
-    do('new keyring {}'.format(name), expect=newKeyringOut, mapper=aliceMap)
+    do('new wallet {}'.format(name), expect=newKeyringOut, mapper=aliceMap)
     do('connect test', within=within, expect=connectedToTest)
     with pytest.raises(Exit):
         do('exit')

--- a/sovrin_client/test/cli/test_command_reg_ex.py
+++ b/sovrin_client/test/cli/test_command_reg_ex.py
@@ -195,16 +195,16 @@ def testPingTargetRegEx(grammar):
 
 
 def testAcceptInvitationLinkRegEx(grammar):
-    matchedVars = getMatchedVariables(grammar, "accept invitation from faber")
-    assertCliTokens(matchedVars, {"accept_link_invite": "accept invitation from",
+    matchedVars = getMatchedVariables(grammar, "accept request from faber")
+    assertCliTokens(matchedVars, {"accept_connection_request": "accept request from",
                                   "link_name": "faber"})
 
-    matchedVars = getMatchedVariables(grammar, 'accept invitation from "faber"')
-    assertCliTokens(matchedVars, {"accept_link_invite": "accept invitation from",
+    matchedVars = getMatchedVariables(grammar, 'accept request from "faber"')
+    assertCliTokens(matchedVars, {"accept_connection_request": "accept request from",
                                   "link_name": '"faber"'})
 
-    matchedVars = getMatchedVariables(grammar, 'accept invitation from "faber" ')
-    assertCliTokens(matchedVars, {"accept_link_invite": "accept invitation from",
+    matchedVars = getMatchedVariables(grammar, 'accept request from "faber" ')
+    assertCliTokens(matchedVars, {"accept_connection_request": "accept request from",
                                   "link_name": '"faber" '})
 
 
@@ -287,27 +287,27 @@ def testDisconnect(grammar):
 
 def testNewIdentifier(grammar):
     matchedVars = getMatchedVariables(
-        grammar, "new identifier")
-    assertCliTokens(matchedVars, {"new_id": "new identifier",
+        grammar, "new DID")
+    assertCliTokens(matchedVars, {"new_id": "new DID",
                                   "id": None,
                                   "seed": None, "alias": None})
 
     matchedVars = getMatchedVariables(
-        grammar, "new identifier as myalis")
+        grammar, "new DID as myalis")
     assertCliTokens(matchedVars,
-                    {"new_id": "new identifier", "id": None,
+                    {"new_id": "new DID", "id": None,
                      "seed": None, "alias": "myalis"})
 
     matchedVars = getMatchedVariables(
-        grammar, "new identifier 4QxzWk3ajdnEA37NdNU5Kt")
-    assertCliTokens(matchedVars, {"new_id": "new identifier",
+        grammar, "new DID 4QxzWk3ajdnEA37NdNU5Kt")
+    assertCliTokens(matchedVars, {"new_id": "new DID",
                                   "id": "4QxzWk3ajdnEA37NdNU5Kt",
                                   "seed": None, "alias": None})
 
     matchedVars = getMatchedVariables(
-        grammar, "new identifier 4QxzWk3ajdnEA37NdNU5Kt "
+        grammar, "new DID 4QxzWk3ajdnEA37NdNU5Kt "
                  "with seed aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    assertCliTokens(matchedVars, {"new_id": "new identifier",
+    assertCliTokens(matchedVars, {"new_id": "new DID",
                                   "id": "4QxzWk3ajdnEA37NdNU5Kt",
                                   "seed": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                                   "alias": None})
@@ -333,7 +333,7 @@ def testAddGenTxnRegEx(grammar):
                                       '{"node_ip": "localhost", "node_port": "9701", "client_ip": "localhost", "client_port": "9702", "alias": "AliceNode"}')
     assertCliTokens(matchedVars, {"add_gen_txn": "add genesis transaction", "type": "NODE",
                                   "dest": "2ru5PcgeQzxF7QZYwQgDkG2K13PRqyigVw99zMYg8eML",
-                                  "identifier": "FvDi9xQZd1CZitbK15BNKFbA7izCdXZjvxf91u3rQVzW", "role": None,
+                                  "DID": "FvDi9xQZd1CZitbK15BNKFbA7izCdXZjvxf91u3rQVzW", "role": None,
                                   "data": '{"node_ip": "localhost", "node_port": "9701", "client_ip": "localhost", "client_port": "9702", "alias": "AliceNode"}'})
 
 

--- a/sovrin_client/test/cli/test_command_reg_ex.py
+++ b/sovrin_client/test/cli/test_command_reg_ex.py
@@ -159,16 +159,16 @@ def testLoadFileCommandRegEx(grammar):
 
 
 def testShowLinkRegEx(grammar):
-    matchedVars = getMatchedVariables(grammar, "show link faber")
-    assertCliTokens(matchedVars, {"show_link": "show link",
+    matchedVars = getMatchedVariables(grammar, "show connection faber")
+    assertCliTokens(matchedVars, {"show_connection": "show connection",
                                   "link_name": "faber"})
 
-    matchedVars = getMatchedVariables(grammar, "show link faber college")
-    assertCliTokens(matchedVars, {"show_link": "show link",
+    matchedVars = getMatchedVariables(grammar, "show connection faber college")
+    assertCliTokens(matchedVars, {"show_connection": "show connection",
                                   "link_name": "faber college"})
 
-    matchedVars = getMatchedVariables(grammar, "show link faber college ")
-    assertCliTokens(matchedVars, {"show_link": "show link",
+    matchedVars = getMatchedVariables(grammar, "show connection faber college ")
+    assertCliTokens(matchedVars, {"show_connection": "show connection",
                                   "link_name": "faber college "})
 
 

--- a/sovrin_client/test/cli/test_command_reg_ex.py
+++ b/sovrin_client/test/cli/test_command_reg_ex.py
@@ -180,13 +180,13 @@ def testConnectRegEx(grammar):
 
 def testSyncLinkRegEx(grammar):
     matchedVars = getMatchedVariables(grammar, "sync faber")
-    assertCliTokens(matchedVars, {"sync_link": "sync", "link_name": "faber"})
+    assertCliTokens(matchedVars, {"sync_connection": "sync", "link_name": "faber"})
 
     matchedVars = getMatchedVariables(grammar, 'sync "faber"')
-    assertCliTokens(matchedVars, {"sync_link": "sync", "link_name": '"faber"'})
+    assertCliTokens(matchedVars, {"sync_connection": "sync", "link_name": '"faber"'})
 
     matchedVars = getMatchedVariables(grammar, 'sync "faber" ')
-    assertCliTokens(matchedVars, {"sync_link": "sync", "link_name": '"faber" '})
+    assertCliTokens(matchedVars, {"sync_connection": "sync", "link_name": '"faber" '})
 
 
 def testPingTargetRegEx(grammar):

--- a/sovrin_client/test/cli/test_command_reg_ex.py
+++ b/sovrin_client/test/cli/test_command_reg_ex.py
@@ -333,7 +333,7 @@ def testAddGenTxnRegEx(grammar):
                                       '{"node_ip": "localhost", "node_port": "9701", "client_ip": "localhost", "client_port": "9702", "alias": "AliceNode"}')
     assertCliTokens(matchedVars, {"add_gen_txn": "add genesis transaction", "type": "NODE",
                                   "dest": "2ru5PcgeQzxF7QZYwQgDkG2K13PRqyigVw99zMYg8eML",
-                                  "DID": "FvDi9xQZd1CZitbK15BNKFbA7izCdXZjvxf91u3rQVzW", "role": None,
+                                  "identifier": "FvDi9xQZd1CZitbK15BNKFbA7izCdXZjvxf91u3rQVzW", "role": None,
                                   "data": '{"node_ip": "localhost", "node_port": "9701", "client_ip": "localhost", "client_port": "9702", "alias": "AliceNode"}'})
 
 

--- a/sovrin_client/test/cli/test_new_identifier.py
+++ b/sovrin_client/test/cli/test_new_identifier.py
@@ -14,7 +14,7 @@ def checkWalletState(cli, totalIds, isAbbr, isCrypto):
                     format(activeSigner.verkey)
 
             assert cli._activeWallet.defaultId != activeSigner.verkey, \
-                "new identifier should not be equal to abbreviated verkey"
+                "new DID should not be equal to abbreviated verkey"
 
         if isCrypto:
             assert not activeSigner.verkey.startswith("~"), \
@@ -22,7 +22,7 @@ def checkWalletState(cli, totalIds, isAbbr, isCrypto):
                     format(activeSigner.verkey)
 
             assert cli._activeWallet.defaultId == activeSigner.verkey, \
-                "new identifier should be equal to verkey"
+                "new DID should be equal to verkey"
 
 
 def getTotalIds(cli):
@@ -36,21 +36,21 @@ def testNewIdWithIncorrectSeed(be, do, aliceCLI):
     totalIds = getTotalIds(aliceCLI)
     be(aliceCLI)
     # Seed not of length 32 or 64
-    do("new identifier with seed aaaaaaaaaaa",
+    do("new DID with seed aaaaaaaaaaa",
        expect=["Seed needs to be 32 or 64 characters (if hex) long"])
     checkWalletState(aliceCLI, totalIds=totalIds, isAbbr=False, isCrypto=False)
 
     # Seed of length 64 but not hex
-    do("new identifier with seed "
+    do("new DID with seed "
        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
        expect=["Seed needs to be 32 or 64 characters (if hex) long"])
     checkWalletState(aliceCLI, totalIds=totalIds, isAbbr=False,
                      isCrypto=False)
 
     # Seed of length 64 and hex
-    do("new identifier with seed "
+    do("new DID with seed "
        "2af3d062450c942be50ee766ce2571a6c75c0aca0de322293e7e9f116959c9c3",
-       expect=["Current identifier set to"])
+       expect=["Current DID set to"])
     checkWalletState(aliceCLI, totalIds=totalIds+1, isAbbr=False,
                      isCrypto=False)
 
@@ -58,15 +58,15 @@ def testNewIdWithIncorrectSeed(be, do, aliceCLI):
 def testNewIdIsNotInvalidCommand(be, do, aliceCLI):
     totalIds = getTotalIds(aliceCLI)
     be(aliceCLI)
-    do("new identifier", not_expect=["Invalid command"])
+    do("new DID", not_expect=["Invalid command"])
     checkWalletState(aliceCLI, totalIds=totalIds+1, isAbbr=False, isCrypto=False)
 
 
 def testNewId(be, do, aliceCLI):
     totalIds = getTotalIds(aliceCLI)
     be(aliceCLI)
-    do("new identifier",
-       expect=["Current identifier set to"])
+    do("new DID",
+       expect=["Current DID set to"])
     checkWalletState(aliceCLI, totalIds=totalIds+1, isAbbr=False, isCrypto=False)
 
 

--- a/sovrin_client/test/cli/test_nym.py
+++ b/sovrin_client/test/cli/test_nym.py
@@ -103,7 +103,7 @@ def testAddCID(cidAdded):
 
 
 def getNoVerkeyEverAssignedMsgs(idr):
-    return ["No verkey ever assigned to the identifier {}".format(idr)]
+    return ["No verkey ever assigned to the DID {}".format(idr)]
 
 
 def testGetDIDWithoutVerkey(be, do, philCli, didAdded, trust_anchor_did_signer):
@@ -112,7 +112,7 @@ def testGetDIDWithoutVerkey(be, do, philCli, didAdded, trust_anchor_did_signer):
 
 
 def getVerkeyIsSameAsIdentifierMsgs(idr):
-    return ["Current verkey is same as identifier {}".format(idr)]
+    return ["Current verkey is same as DID {}".format(idr)]
 
 
 def testGetCIDWithoutVerkey(be, do, philCli, cidAdded, trust_anchor_cid_signer):

--- a/sovrin_client/test/cli/test_nym_suspension.py
+++ b/sovrin_client/test/cli/test_nym_suspension.py
@@ -79,8 +79,8 @@ def trustAnchorCLI(CliBuilder):
 @pytest.fixture(scope="module")
 def trustAnchorCli(trustAnchorCLI, be, do, connectedToTest, trustAnchorAdded):
     be(trustAnchorCLI)
-    do('new wallet TS', expect=['New keyring TS created',
-                                   'Active keyring set to "TS"'])
+    do('new wallet TS', expect=['New wallet TS created',
+                                   'Active wallet set to "TS"'])
     seed = hexlify(vals['newTrustAnchorIdr'][1]).decode()
     do('new key with seed {seed}', expect=['Key created in keyring TS'],
        mapper={'seed': seed})
@@ -96,8 +96,8 @@ def anotherTrusteeCLI(CliBuilder):
 @pytest.fixture(scope="module")
 def anotherTrusteeCli(anotherTrusteeCLI, be, do, connectedToTest, anotherTrusteeAdded):
     be(anotherTrusteeCLI)
-    do('new wallet TS1', expect=['New keyring TS1 created',
-                                   'Active keyring set to "TS1"'])
+    do('new wallet TS1', expect=['New wallet TS1 created',
+                                   'Active wallet set to "TS1"'])
     seed = hexlify(vals['newTrusteeIdr'][1]).decode()
     do('new key with seed {seed}', expect=['Key created in keyring TS1'],
        mapper={'seed': seed})

--- a/sovrin_client/test/cli/test_nym_suspension.py
+++ b/sovrin_client/test/cli/test_nym_suspension.py
@@ -82,7 +82,7 @@ def trustAnchorCli(trustAnchorCLI, be, do, connectedToTest, trustAnchorAdded):
     do('new wallet TS', expect=['New wallet TS created',
                                    'Active wallet set to "TS"'])
     seed = hexlify(vals['newTrustAnchorIdr'][1]).decode()
-    do('new key with seed {seed}', expect=['Key created in keyring TS'],
+    do('new key with seed {seed}', expect=['Key created in wallet TS'],
        mapper={'seed': seed})
     do('connect test', within=3, expect=connectedToTest)
     return trustAnchorCLI
@@ -99,7 +99,7 @@ def anotherTrusteeCli(anotherTrusteeCLI, be, do, connectedToTest, anotherTrustee
     do('new wallet TS1', expect=['New wallet TS1 created',
                                    'Active wallet set to "TS1"'])
     seed = hexlify(vals['newTrusteeIdr'][1]).decode()
-    do('new key with seed {seed}', expect=['Key created in keyring TS1'],
+    do('new key with seed {seed}', expect=['Key created in wallet TS1'],
        mapper={'seed': seed})
     do('connect test', within=3, expect=connectedToTest)
     return anotherTrusteeCLI

--- a/sovrin_client/test/cli/test_nym_suspension.py
+++ b/sovrin_client/test/cli/test_nym_suspension.py
@@ -79,7 +79,7 @@ def trustAnchorCLI(CliBuilder):
 @pytest.fixture(scope="module")
 def trustAnchorCli(trustAnchorCLI, be, do, connectedToTest, trustAnchorAdded):
     be(trustAnchorCLI)
-    do('new keyring TS', expect=['New keyring TS created',
+    do('new wallet TS', expect=['New keyring TS created',
                                    'Active keyring set to "TS"'])
     seed = hexlify(vals['newTrustAnchorIdr'][1]).decode()
     do('new key with seed {seed}', expect=['Key created in keyring TS'],
@@ -96,7 +96,7 @@ def anotherTrusteeCLI(CliBuilder):
 @pytest.fixture(scope="module")
 def anotherTrusteeCli(anotherTrusteeCLI, be, do, connectedToTest, anotherTrusteeAdded):
     be(anotherTrusteeCLI)
-    do('new keyring TS1', expect=['New keyring TS1 created',
+    do('new wallet TS1', expect=['New keyring TS1 created',
                                    'Active keyring set to "TS1"'])
     seed = hexlify(vals['newTrusteeIdr'][1]).decode()
     do('new key with seed {seed}', expect=['Key created in keyring TS1'],

--- a/sovrin_client/test/cli/test_pool_upgrade.py
+++ b/sovrin_client/test/cli/test_pool_upgrade.py
@@ -21,7 +21,7 @@ def send_upgrade_cmd(do, expect, upgrade_data):
 @pytest.fixture(scope="module")
 def poolUpgradeSubmitted(be, do, trusteeCli, validUpgrade):
     be(trusteeCli)
-    send_upgrade_cmd(do, ['Sending pool upgrade', 'Pool upgrade successful'],
+    send_upgrade_cmd(do, ['Sending pool upgrade', 'Pool Upgrade Transaction Scheduled'],
                      validUpgrade)
 
 
@@ -44,7 +44,7 @@ def poolUpgradeCancelled(poolUpgradeScheduled, be, do, trusteeCli,
     do('send POOL_UPGRADE name={name} version={version} sha256={sha256} '
        'action={action} justification={justification}',
        within=10,
-       expect=['Sending pool upgrade', 'Pool upgrade successful'],
+       expect=['Sending pool upgrade', 'Pool Upgrade Transaction Scheduled'],
        mapper=validUpgrade)
 
 
@@ -82,7 +82,7 @@ def send_force_false_upgrade_cmd(do, expect, upgrade_data):
 
 def test_force_false_upgrade(be, do, trusteeCli, poolNodesStarted, validUpgradeExpForceFalse):
     be(trusteeCli)
-    send_force_false_upgrade_cmd(do, ['Sending pool upgrade', 'Pool upgrade successful'], validUpgradeExpForceFalse)
+    send_force_false_upgrade_cmd(do, ['Sending pool upgrade', 'Pool Upgrade Transaction Scheduled'], validUpgradeExpForceFalse)
     poolNodesStarted.looper.run(
         eventually(checkUpgradeScheduled, poolNodesStarted.nodes.values(),
                    validUpgradeExpForceFalse[VERSION], retryWait=1, timeout=10))

--- a/sovrin_client/test/cli/test_proof_request.py
+++ b/sovrin_client/test/cli/test_proof_request.py
@@ -1,3 +1,3 @@
 def test_show_nonexistant_proof_request(be, do, aliceCLI):
     be(aliceCLI)
-    do("show proof request Transcript", expect=["No matching Proof Requests found in current keyring"], within=1)
+    do("show proof request Transcript", expect=["No matching Proof Requests found in current wallet"], within=1)

--- a/sovrin_client/test/cli/test_save_and_restore_wallet.py
+++ b/sovrin_client/test/cli/test_save_and_restore_wallet.py
@@ -53,8 +53,8 @@ def connectTo(envName, do, cli, activeWalletPresents, identifiers,
     _connectTo(envName, do, cli)
     if currActiveWallet is None and firstTimeConnect:
         do(None, expect=[
-            "New keyring Default created",
-            'Active keyring set to "Default"']
+            "New wallet Default created",
+            'Active wallet set to "Default"']
         )
 
     if activeWalletPresents:
@@ -92,13 +92,13 @@ def restartCliWithCorruptedWalletFile(cli, be, do, filePath):
     do(None,
        expect=[
            'error occurred while restoring wallet',
-           'New keyring Default_',
-           'Active keyring set to "Default_',
+           'New wallet Default_',
+           'Active wallet set to "Default_',
        ],
        not_expect=[
-           'Saved keyring "Default" restored',
-           'New keyring Default created',
-           'Active keyring set to "Default"'
+           'Saved wallet "Default" restored',
+           'New wallet Default created',
+           'Active wallet set to "Default"'
     ], within=5)
 
 

--- a/sovrin_client/test/cli/test_save_and_restore_wallet.py
+++ b/sovrin_client/test/cli/test_save_and_restore_wallet.py
@@ -38,7 +38,7 @@ def testPersistentWalletName():
 
 def getActiveWalletFilePath(cli):
     fileName = cli.getActiveWalletPersitentFileName()
-    return getWalletFilePath(cli.getContextBasedKeyringsBaseDir(), fileName)
+    return getWalletFilePath(cli.getContextBasedWalletsBaseDir(), fileName)
 
 
 def _connectTo(envName, do, cli):
@@ -145,7 +145,7 @@ def testSaveAndRestoreWallet(do, be, cliForMultiNodePools,
                          '"mykr0" conflicts with an existing wallet',
                          'Please choose a new name.'])
 
-    filePath = getWalletFilePath(cliForMultiNodePools.getContextBasedKeyringsBaseDir(),
+    filePath = getWalletFilePath(cliForMultiNodePools.getContextBasedWalletsBaseDir(),
                                      cliForMultiNodePools.walletFileName)
     switchEnv("pool1", do, cliForMultiNodePools, checkIfWalletRestored=True,
               restoredWalletKeyName="mykr1", restoredIdentifiers=1)
@@ -159,7 +159,7 @@ def testSaveAndRestoreWallet(do, be, cliForMultiNodePools,
     exitFromCli(do)
 
     # different tests for restoring saved wallet
-    filePath = getWalletFilePath(cliForMultiNodePools.getContextBasedKeyringsBaseDir(),
+    filePath = getWalletFilePath(cliForMultiNodePools.getContextBasedWalletsBaseDir(),
                                      cliForMultiNodePools.walletFileName)
     restartCli(aliceMultiNodePools, be, do, "mykr1", 1)
     restartCliWithCorruptedWalletFile(earlMultiNodePools, be, do, filePath)
@@ -170,7 +170,7 @@ def testRestoreWalletFile(aliceCLI):
     fileName = "tmp_wallet_restore_issue"
     curPath = os.path.dirname(os.path.realpath(__file__))
     walletFilePath = os.path.join(curPath, fileName)
-    noEnvKeyringsDir = os.path.join(aliceCLI.getKeyringsBaseDir(), NO_ENV)
+    noEnvKeyringsDir = os.path.join(aliceCLI.getWalletsBaseDir(), NO_ENV)
     createDirIfNotExists(noEnvKeyringsDir)
     shutil.copy2(walletFilePath, noEnvKeyringsDir)
     targetWalletFilePath = os.path.join(noEnvKeyringsDir, fileName)

--- a/sovrin_client/test/cli/test_save_and_restore_wallet.py
+++ b/sovrin_client/test/cli/test_save_and_restore_wallet.py
@@ -142,7 +142,7 @@ def testSaveAndRestoreWallet(do, be, cliForMultiNodePools,
               restoredWalletKeyName="Default", restoredIdentifiers=2)
     createNewKeyring("mykr0", do,
                      expectedMsgs = [
-                         '"mykr0" conflicts with an existing keyring',
+                         '"mykr0" conflicts with an existing wallet',
                          'Please choose a new name.'])
 
     filePath = getWalletFilePath(cliForMultiNodePools.getContextBasedKeyringsBaseDir(),

--- a/sovrin_client/test/cli/test_tutorial.py
+++ b/sovrin_client/test/cli/test_tutorial.py
@@ -134,7 +134,7 @@ def connectIfNotAlreadyConnected(do, expectMsgs, userCli, userMap):
 
 def setPromptAndKeyring(do, name, newKeyringOut, userMap):
     do('prompt {}'.format(name), expect=prompt_is(name))
-    do('new keyring {}'.format(name), expect=newKeyringOut, mapper=userMap)
+    do('new wallet {}'.format(name), expect=newKeyringOut, mapper=userMap)
 
 
 @pytest.fixture(scope="module")

--- a/sovrin_client/test/cli/test_tutorial.py
+++ b/sovrin_client/test/cli/test_tutorial.py
@@ -953,7 +953,7 @@ def testAliceReqAvailClaimsFromNonExistentConnection(
         be, do, aliceCli, bankKYCProofSent, faberMap):
     be(aliceCli)
     do('request available claims from dummy-link', mapper=faberMap,
-       expect=["No matching link invitations found in current keyring"])
+       expect=["No matching link invitations found in current wallet"])
 
 
 def testAliceReqAvailClaimsFromFaber(

--- a/sovrin_client/test/cli/test_tutorial.py
+++ b/sovrin_client/test/cli/test_tutorial.py
@@ -261,7 +261,7 @@ def testShowFaberLink(be, do, aliceCli, faberInviteLoadedByAlice,
     be(aliceCli)
     cp = faberMap.copy()
     cp.update(endpoint='<unknown, waiting for sync>',
-              last_synced='<this link has not yet been synchronized>')
+              last_synced='<this connection has not yet been synchronized>')
     do('show connection {inviter}', expect=showUnSyncedLinkOut, mapper=cp)
 
 
@@ -283,7 +283,7 @@ def testAcceptUnSyncedFaberInviteWhenNotConnected(be, do, aliceCli,
                                                   acceptUnSyncedWhenNotConnected,
                                                   faberMap):
     be(aliceCli)
-    do('accept invitation from {inviter}',
+    do('accept request from {inviter}',
        expect=acceptUnSyncedWhenNotConnected,
        mapper=faberMap)
 
@@ -333,7 +333,7 @@ def testShowSyncedFaberInvite(be, do, aliceCli, faberMap, linkNotYetSynced,
 
     cp = faberMap.copy()
     cp.update(endpoint='<unknown, waiting for sync>',
-              last_synced='<this link has not yet been synchronized>')
+              last_synced='<this connection has not yet been synchronized>')
 
     do('show connection {inviter}', within=4,
        expect=showSyncedLinkWithoutEndpointOut,
@@ -355,7 +355,7 @@ def faberInviteSyncedWithEndpoint(be, do, faberMap, aliceCLI, preRequisite,
                                   faberInviteSyncedWithoutEndpoint,
                                   syncLinkOutWithEndpoint):
     cp = faberMap.copy()
-    cp.update(last_synced='<this link has not yet been synchronized>')
+    cp.update(last_synced='<this connection has not yet been synchronized>')
     syncInvite(be, do, aliceCLI, syncLinkOutWithEndpoint, cp)
     return aliceCLI
 
@@ -381,14 +381,14 @@ def testPingBeforeAccept(be, do, aliceCli, faberMap, connectedToTest,
        within=3,
        expect=[
            'Ping sent.',
-           'Error processing ping. Link is not yet created.'
+           'Error processing ping. Connection is not yet created.'
        ],
        mapper=faberMap)
 
 
 def testAcceptNotExistsLink(be, do, aliceCli, linkNotExists, faberMap):
     be(aliceCli)
-    do('accept invitation from {inviter-not-exists}',
+    do('accept request from {inviter-not-exists}',
        expect=linkNotExists, mapper=faberMap)
 
 
@@ -400,13 +400,13 @@ def getSignedRespMsg(msg, signer):
 
 def acceptInvitation(be, do, userCli, agentMap, expect):
     be(userCli)
-    do("accept invitation from {inviter}",
+    do("accept request from {inviter}",
        within=15,
        mapper=agentMap,
        expect=expect,
        not_expect=[
            "Observer threw an exception",
-           "Identifier is not yet written to Sovrin"]
+           "DID is not yet written to Sovrin"]
        )
     li = userCli.agent.wallet.getLinkBy(nonce=agentMap['nonce'])
     assert li
@@ -559,7 +559,7 @@ def testShowAcmeLink(be, do, aliceCli, acmeInviteLoadedByAlice,
     be(aliceCli)
 
     cp = acmeMap.copy()
-    cp.update(last_synced='<this link has not yet been synchronized>')
+    cp.update(last_synced='<this connection has not yet been synchronized>')
     do('show connection {inviter}', expect=showUnSyncedLinkWithClaimReqs, mapper=cp)
 
 
@@ -594,7 +594,7 @@ def testShowAcmeLinkAfterInviteAccept(be, do, aliceCli, acmeMap,
     be(aliceCli)
 
     do("show connection {inviter}", expect=showAcceptedLinkWithoutAvailableClaimsOut,
-       not_expect="Link (not yet accepted)",
+       not_expect="Connection (not yet accepted)",
        mapper=acmeMap)
 
 
@@ -953,7 +953,7 @@ def testAliceReqAvailClaimsFromNonExistentConnection(
         be, do, aliceCli, bankKYCProofSent, faberMap):
     be(aliceCli)
     do('request available claims from dummy-link', mapper=faberMap,
-       expect=["No matching connection invitations found in current wallet"])
+       expect=["No matching connection requests found in current wallet"])
 
 
 def testAliceReqAvailClaimsFromFaber(

--- a/sovrin_client/test/cli/test_tutorial.py
+++ b/sovrin_client/test/cli/test_tutorial.py
@@ -934,8 +934,8 @@ def restartCliAndTestWalletRestoration(be, do, cli, connectedToTest):
     be(cli)
     connectIfNotAlreadyConnected(do, connectedToTest, cli, {})
     do(None, expect=[
-        'Saved keyring ',
-        'Active keyring set to '
+        'Saved wallet ',
+        'Active wallet set to '
     ], within=5)
     assert cli._activeWallet is not None
     # assert len(cli._activeWallet._links) == 3

--- a/sovrin_client/test/cli/test_tutorial.py
+++ b/sovrin_client/test/cli/test_tutorial.py
@@ -421,6 +421,9 @@ def aliceAcceptedFaberInvitation(be, do, aliceCli, faberMap,
                                  faberInviteSyncedWithEndpoint):
     acceptInvitation(be, do, aliceCli, faberMap,
                  syncedInviteAcceptedWithClaimsOut)
+    do("list connections", within = 10,
+       mapper=faberMap,
+       expect="Faber College")
     return aliceCli
 
 

--- a/sovrin_client/test/cli/test_tutorial.py
+++ b/sovrin_client/test/cli/test_tutorial.py
@@ -251,7 +251,7 @@ def testLoadFaberInvite(faberInviteLoadedByAlice):
 
 def testShowLinkNotExists(be, do, aliceCli, linkNotExists, faberMap):
     be(aliceCli)
-    do('show link {inviter-not-exists}',
+    do('show connection {inviter-not-exists}',
        expect=linkNotExists,
        mapper=faberMap)
 
@@ -262,7 +262,7 @@ def testShowFaberLink(be, do, aliceCli, faberInviteLoadedByAlice,
     cp = faberMap.copy()
     cp.update(endpoint='<unknown, waiting for sync>',
               last_synced='<this link has not yet been synchronized>')
-    do('show link {inviter}', expect=showUnSyncedLinkOut, mapper=cp)
+    do('show connection {inviter}', expect=showUnSyncedLinkOut, mapper=cp)
 
 
 def testSyncLinkNotExists(be, do, aliceCli, linkNotExists, faberMap):
@@ -335,7 +335,7 @@ def testShowSyncedFaberInvite(be, do, aliceCli, faberMap, linkNotYetSynced,
     cp.update(endpoint='<unknown, waiting for sync>',
               last_synced='<this link has not yet been synchronized>')
 
-    do('show link {inviter}', within=4,
+    do('show connection {inviter}', within=4,
        expect=showSyncedLinkWithoutEndpointOut,
        # TODO, need to come back to not_expect
        # not_expect=linkNotYetSynced,
@@ -370,7 +370,7 @@ def testShowSyncedFaberInviteWithEndpoint(be, do, aliceCLI, faberMap,
     be(aliceCLI)
     cp = faberMap.copy()
     cp.update(last_synced='just now')
-    do('show link {inviter}', expect=showSyncedLinkWithEndpointOut, mapper=cp, within=3)
+    do('show connection {inviter}', expect=showSyncedLinkWithEndpointOut, mapper=cp, within=3)
 
 
 def testPingBeforeAccept(be, do, aliceCli, faberMap, connectedToTest,
@@ -458,7 +458,7 @@ def testShowFaberLinkAfterInviteAccept(be, do, aliceCli, faberMap,
                                        aliceAcceptedFaberInvitation):
     be(aliceCli)
 
-    do("show link {inviter}", expect=showAcceptedLinkOut,
+    do("show connection {inviter}", expect=showAcceptedLinkOut,
        # not_expect="Link (not yet accepted)",
        mapper=faberMap)
 
@@ -560,7 +560,7 @@ def testShowAcmeLink(be, do, aliceCli, acmeInviteLoadedByAlice,
 
     cp = acmeMap.copy()
     cp.update(last_synced='<this link has not yet been synchronized>')
-    do('show link {inviter}', expect=showUnSyncedLinkWithClaimReqs, mapper=cp)
+    do('show connection {inviter}', expect=showUnSyncedLinkWithClaimReqs, mapper=cp)
 
 
 @pytest.fixture(scope="module")
@@ -593,7 +593,7 @@ def testShowAcmeLinkAfterInviteAccept(be, do, aliceCli, acmeMap,
                                       showAcceptedLinkWithoutAvailableClaimsOut):
     be(aliceCli)
 
-    do("show link {inviter}", expect=showAcceptedLinkWithoutAvailableClaimsOut,
+    do("show connection {inviter}", expect=showAcceptedLinkWithoutAvailableClaimsOut,
        not_expect="Link (not yet accepted)",
        mapper=acmeMap)
 
@@ -789,7 +789,7 @@ def testShowAcmeLinkAfterClaimSent(be, do, aliceCli, acmeMap,
     mapping["claims"] = "Job-Certificate"
 
     acmeMap.update(acmeMap)
-    do("show link {inviter}", expect=showAcceptedLinkWithAvailableClaimsOut,
+    do("show connection {inviter}", expect=showAcceptedLinkWithAvailableClaimsOut,
        mapper=mapping)
 
 
@@ -953,7 +953,7 @@ def testAliceReqAvailClaimsFromNonExistentConnection(
         be, do, aliceCli, bankKYCProofSent, faberMap):
     be(aliceCli)
     do('request available claims from dummy-link', mapper=faberMap,
-       expect=["No matching link invitations found in current wallet"])
+       expect=["No matching connection invitations found in current wallet"])
 
 
 def testAliceReqAvailClaimsFromFaber(

--- a/sovrin_client/test/cli/test_tutorial_manual.py
+++ b/sovrin_client/test/cli/test_tutorial_manual.py
@@ -70,7 +70,7 @@ def testManual(do, be, poolNodesStarted, poolTxnStewardData, philCli,
     # Create steward and add nyms and endpoint attributes of all agents
     _, stewardSeed = poolTxnStewardData
     be(philCli)
-    do('new keyring Steward', expect=['New keyring Steward created',
+    do('new wallet Steward', expect=['New keyring Steward created',
                                       'Active keyring set to "Steward"'])
 
     mapper = {'seed': stewardSeed.decode()}

--- a/sovrin_client/test/cli/test_tutorial_manual.py
+++ b/sovrin_client/test/cli/test_tutorial_manual.py
@@ -74,7 +74,7 @@ def testManual(do, be, poolNodesStarted, poolTxnStewardData, philCli,
                                       'Active wallet set to "Steward"'])
 
     mapper = {'seed': stewardSeed.decode()}
-    do('new key with seed {seed}', expect=['Key created in keyring Steward'],
+    do('new key with seed {seed}', expect=['Key created in wallet Steward'],
        mapper=mapper)
     do('connect test', within=3, expect=connectedToTest)
 

--- a/sovrin_client/test/cli/test_tutorial_manual.py
+++ b/sovrin_client/test/cli/test_tutorial_manual.py
@@ -70,8 +70,8 @@ def testManual(do, be, poolNodesStarted, poolTxnStewardData, philCli,
     # Create steward and add nyms and endpoint attributes of all agents
     _, stewardSeed = poolTxnStewardData
     be(philCli)
-    do('new wallet Steward', expect=['New keyring Steward created',
-                                      'Active keyring set to "Steward"'])
+    do('new wallet Steward', expect=['New wallet Steward created',
+                                      'Active wallet set to "Steward"'])
 
     mapper = {'seed': stewardSeed.decode()}
     do('new key with seed {seed}', expect=['Key created in keyring Steward'],

--- a/sovrin_common/test/conftest.py
+++ b/sovrin_common/test/conftest.py
@@ -1,8 +1,10 @@
 import pytest
+import logging
 
 from sovrin_common import strict_types
 from sovrin_common.config_util import getConfig
 from sovrin_common.txn_util import getTxnOrderedFields
+from stp_core.common.log import getlogger
 
 # typecheck during tests
 strict_types.defaultShouldCheck = True
@@ -36,3 +38,9 @@ def looper(txnPoolNodesLooper):
 @pytest.fixture(scope="module")
 def domainTxnOrderedFields():
     return getTxnOrderedFields()
+
+
+@pytest.fixture(autouse=True)
+def setTestLogLevel():
+    logger = getlogger()
+    logger.level = logging.NOTSET

--- a/sovrin_common/types.py
+++ b/sovrin_common/types.py
@@ -9,13 +9,12 @@ from plenum.common.request import Request as PRequest
 from plenum.common.types import OPERATION
 from plenum.common.messages.node_messages import \
     ConstantField, IdentifierField, NonEmptyStringField, \
-    JsonField, NonNegativeNumberField, IterableField, MapField, LedgerIdField as PLedgerIdField, \
-    BooleanField, LimitedLengthStringField, TxnSeqNoField, Sha256HexField, \
-    LedgerInfoField as PLedgerInfoField, \
-    JsonField, NonNegativeNumberField, MapField, LedgerIdField as PLedgerIdField, BooleanField, VersionField
+    LimitedLengthStringField, TxnSeqNoField, Sha256HexField, \
+    LedgerInfoField as PLedgerInfoField, JsonField, NonNegativeNumberField, \
+    MapField, LedgerIdField as PLedgerIdField, BooleanField, VersionField
 from plenum.common.messages.client_request import ClientOperationField as PClientOperationField
 from plenum.common.messages.client_request import ClientMessageValidator as PClientMessageValidator
-from plenum.common.util import check_endpoint_valid, is_network_ip_address_valid, is_network_port_valid
+from plenum.common.util import is_network_ip_address_valid, is_network_port_valid
 
 from sovrin_common.constants import *
 

--- a/sovrin_node/test/conftest.py
+++ b/sovrin_node/test/conftest.py
@@ -45,7 +45,7 @@ from plenum.test.conftest import tdir, nodeReg, up, ready, \
 
 # noinspection PyUnresolvedReferences
 from sovrin_common.test.conftest import conf, tconf, poolTxnTrusteeNames, \
-    domainTxnOrderedFields, looper
+    domainTxnOrderedFields, looper, setTestLogLevel
 
 Logger.setLogLevel(logging.NOTSET)
 


### PR DESCRIPTION
This is to change the older vocabulary to the newer way of thinking.

'keyring' -> 'wallet'
'link' -> 'connection'
'invitation' -> 'request'
'identifier' -> 'DID'

This change many commands, for example 'new identifier' is now 'new DID'.  The help message and the details within the commands reflect these changes.

until PR https://github.com/hyperledger/indy-plenum/pull/296 is merged, these tests will fail.