### PR TITLE
Walleted.py merge_request Did Not Work

### DIFF
--- a/sovrin_client/agent/walleted.py
+++ b/sovrin_client/agent/walleted.py
@@ -832,6 +832,7 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
         link = self.wallet.getConnection(linkName)
         request_proof_requests = request_data.get('proof-requests',
                                                    None)
+        nonce = link_request.get('nonce') or "1"
         if request_proof_requests:
             for icr in request_proof_requests:
                 # match is found if name and version are same
@@ -856,8 +857,8 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
                     # otherwise append proof request to link
                     link.proofRequests.append(
                         ProofRequest(
-                            icr[NAME], icr[VERSION], icr[ATTRIBUTES],
-                            icr[VERIFIABLE_ATTRIBUTES]
+                            icr[NAME], icr[VERSION], getNonceForProof(nonce), attributes=icr[ATTRIBUTES],
+                            verifiableAttributes=icr[VERIFIABLE_ATTRIBUTES]
                         )
                     )
 

--- a/sovrin_client/agent/walleted.py
+++ b/sovrin_client/agent/walleted.py
@@ -530,7 +530,7 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
                         [rc.get(NAME) for rc in rcvdAvailableClaims])))
                 try:
                     self._checkIfLinkIdentifierWrittenToSovrin(li,
-                                                           newAvailableClaims)
+                                                               newAvailableClaims)
                 except NotConnectedToAny:
                     self.notifyEventListeners(
                         EVENT_NOT_CONNECTED_TO_ANY_ENV,
@@ -669,7 +669,7 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
             logger.debug("already accepted, "
                          "so directly sending available claims")
             self.logger.info('Already added identifier [{}] in sovrin'
-                                  .format(identifier))
+                             .format(identifier))
             # self.notifyToRemoteCaller(EVENT_NOTIFY_MSG,
             #                       "    Already accepted",
             #                       link.verkey, frm)
@@ -685,7 +685,7 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
             # anyhow this class should be implemented by each agent
             # so we might not even need to add it as a separate logic
             self.logger.info('Creating identifier [{}] in sovrin'
-                                  .format(identifier))
+                             .format(identifier))
             self._sendToSovrinAndDo(reqs[0], clbk=send_claims)
 
             # TODO: If I have the below exception thrown, somehow the
@@ -744,10 +744,11 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
         if publicKeyRaw is None:
             publicKeyRaw = rawVerkeyToPubkey(verKeyRaw)
         self.endpoint.connectIfNotConnected(
-                         name=link.name,
-                         ha=ha,
-                         verKeyRaw=verKeyRaw,
-                         publicKeyRaw=publicKeyRaw)
+            name=link.name,
+            ha=ha,
+            verKeyRaw=verKeyRaw,
+            publicKeyRaw=publicKeyRaw)
+
     # duplicate function
     # def loadInvitationFile(self, filePath):
     #     with open(filePath) as data_file:
@@ -831,8 +832,8 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
         linkName = link_request['name']
         link = self.wallet.getConnection(linkName)
         request_proof_requests = request_data.get('proof-requests',
-                                                   None)
-        nonce = link_request.get('nonce') or "1"
+                                                  None)
+        nonce = link_request.get(NONCE)
         if request_proof_requests:
             for icr in request_proof_requests:
                 # match is found if name and version are same
@@ -849,10 +850,9 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
                         **matchedProofRequest.attributes,
                         **icr[ATTRIBUTES]
                     }
-                    matchedProofRequest.verifiableAttributes = list(
-                        set(matchedProofRequest.verifiableAttributes)
-                        .union(icr[VERIFIABLE_ATTRIBUTES])
-                    )
+                    matchedProofRequest.verifiableAttributes = dict(matchedProofRequest.verifiableAttributes,
+                                                                    **icr[VERIFIABLE_ATTRIBUTES])
+
                 else:
                     # otherwise append proof request to link
                     link.proofRequests.append(
@@ -967,7 +967,6 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
         req = self.wallet.requestIdentity(identity,
                                           sender=self.wallet.defaultId)
 
-
         self.client.submitReqs(req)
 
         self.loop.call_later(.2,
@@ -991,7 +990,6 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
                              req.key,
                              self.client,
                              self._handleSyncResp(link, doneCallback))
-
 
     def executeWhenResponseRcvd(self, startTime, maxCheckForMillis,
                                 loop, reqId, respType,
@@ -1025,4 +1023,3 @@ class Walleted(AgentIssuer, AgentProver, AgentVerifier):
                 loop.call_later(.2, self.executeWhenResponseRcvd,
                                 startTime, maxCheckForMillis, loop,
                                 reqId, respType, checkIfLinkExists, clbk, *args)
-

--- a/sovrin_client/test/cli/test_merge_invitation.py
+++ b/sovrin_client/test/cli/test_merge_invitation.py
@@ -1,0 +1,29 @@
+import pytest
+
+from sovrin_client.agent.agent_issuer import AgentIssuer
+from sovrin_client.agent.agent_prover import AgentProver
+from sovrin_client.agent.agent_verifier import AgentVerifier
+from sovrin_client.agent.walleted import Walleted
+from sovrin_client.client.wallet.connection import Connection
+from sovrin_client.client.wallet.wallet import Wallet
+from sovrin_client.agent.walleted_agent import WalletedAgent
+from plenum.common.constants import NAME, VERSION, ATTRIBUTES, VERIFIABLE_ATTRIBUTES
+
+
+def test_merge_invitation():
+    wallet1 = Wallet('wallet1')
+    connection_1 = Connection('connection1')
+    walleted_agent = WalletedAgent(name='wallet1')
+
+    wallet1.addConnection(connection_1)
+    walleted_agent.wallet = wallet1
+    connection = walleted_agent._wallet.getConnection('connection1')
+    assert len(connection.proofRequests) == 0
+    request_data = {'connection-request': {'name': 'connection1'},
+                    'proof-requests': [{NAME: 'proof1', VERSION: '1',
+                                        ATTRIBUTES: {'att_key1': 'att_value1', 'att_key2': 'att_value2'},
+                                        VERIFIABLE_ATTRIBUTES: {'ver_att_key1': 'ver_att_value1'}}]}
+    walleted_agent._merge_request(request_data)
+    assert len(connection.proofRequests) == 1
+    assert len(connection.proofRequests[0].attributes.keys()) == 2
+    assert connection.proofRequests[0].attributes['att_key1'] == 'att_value1'

--- a/sovrin_client/test/cli/test_merge_invitation.py
+++ b/sovrin_client/test/cli/test_merge_invitation.py
@@ -1,16 +1,11 @@
-import pytest
-
-from sovrin_client.agent.agent_issuer import AgentIssuer
-from sovrin_client.agent.agent_prover import AgentProver
-from sovrin_client.agent.agent_verifier import AgentVerifier
-from sovrin_client.agent.walleted import Walleted
 from sovrin_client.client.wallet.connection import Connection
 from sovrin_client.client.wallet.wallet import Wallet
 from sovrin_client.agent.walleted_agent import WalletedAgent
-from plenum.common.constants import NAME, VERSION, ATTRIBUTES, VERIFIABLE_ATTRIBUTES
+from plenum.common.constants import NAME, VERSION, ATTRIBUTES, VERIFIABLE_ATTRIBUTES, NONCE
 
 
 def test_merge_invitation():
+    nonce = "12345"
     wallet1 = Wallet('wallet1')
     connection_1 = Connection('connection1')
     walleted_agent = WalletedAgent(name='wallet1')
@@ -19,11 +14,49 @@ def test_merge_invitation():
     walleted_agent.wallet = wallet1
     connection = walleted_agent._wallet.getConnection('connection1')
     assert len(connection.proofRequests) == 0
-    request_data = {'connection-request': {'name': 'connection1'},
-                    'proof-requests': [{NAME: 'proof1', VERSION: '1',
+    request_data = {'connection-request': {NAME: 'connection1', NONCE: nonce},
+                    'proof-requests': [{NAME: 'proof1',
+                                        VERSION: '1',
                                         ATTRIBUTES: {'att_key1': 'att_value1', 'att_key2': 'att_value2'},
-                                        VERIFIABLE_ATTRIBUTES: {'ver_att_key1': 'ver_att_value1'}}]}
+                                        VERIFIABLE_ATTRIBUTES: {'ver_att_key1': 'ver_att_value1'}}]
+                    }
+
+    # test that a proof request with attributes can be merged into a connection
+    # that already exists but has no proof requests.
     walleted_agent._merge_request(request_data)
     assert len(connection.proofRequests) == 1
     assert len(connection.proofRequests[0].attributes.keys()) == 2
     assert connection.proofRequests[0].attributes['att_key1'] == 'att_value1'
+
+    request_data2 = {'connection-request': {NAME: 'connection1', NONCE: nonce},
+                     'proof-requests': [{NAME: 'proof1', VERSION: '1',
+                                         ATTRIBUTES: {'att_key1': 'att_value1', 'att_key2': 'att_value2',
+                                                      'att_key3': 'att_value3'},
+                                         VERIFIABLE_ATTRIBUTES: {'ver_att_key1': 'ver_att_value1',
+                                                                 'ver_att_key2': 'ver_att_value2'},
+                                         }]
+                     }
+
+    # test that additional attributes and verifiable attributes can be
+    # merged into an already existing proof request
+    walleted_agent._merge_request(request_data2)
+    assert len(connection.proofRequests) == 1
+    assert len(connection.proofRequests[0].attributes.keys()) == 3
+    assert connection.proofRequests[0].attributes['att_key3'] == 'att_value3'
+    assert len(connection.proofRequests[0].verifiableAttributes.keys()) == 2
+
+    request_data3 = {'connection-request': {NAME: 'connection1', NONCE: nonce},
+                     'proof-requests': [{NAME: 'proof2', VERSION: '1',
+                                         ATTRIBUTES: {'att_key1': 'att_value1', 'att_key2': 'att_value2',
+                                                      'att_key3': 'att_value3'},
+                                         VERIFIABLE_ATTRIBUTES: {'ver_att_key1': 'ver_att_value1',
+                                                                 'ver_att_key2': 'ver_att_value2'},
+                                         }]
+                     }
+
+    # test that a second proof from the same connection can be merged
+    walleted_agent._merge_request(request_data3)
+    assert len(connection.proofRequests) == 2
+    assert len(connection.proofRequests[1].attributes.keys()) == 3
+    assert connection.proofRequests[1].attributes['att_key3'] == 'att_value3'
+    assert len(connection.proofRequests[1].verifiableAttributes.keys()) == 2


### PR DESCRIPTION
Positional arguments for the else case when proof
requests already existed case in
_merge_request were not correct and caused
the attributes member to not be created
correctly.