### PR TITLE
fixes for batching "send NYM" requests (INDY-292)

### DIFF
--- a/sovrin_client/test/cli/test_node_demotion.py
+++ b/sovrin_client/test/cli/test_node_demotion.py
@@ -14,7 +14,7 @@ def ensurePoolIsOperable(be, do, cli):
 
 
 #this test messes with other tests so it goes in its own module
-def testStewardCanDemoteNode(
+def test_steward_can_promote_and_demote_own_node(
         be, do, poolNodesStarted, newStewardCli, trusteeCli, newNodeVals):
 
     ensurePoolIsOperable(be, do, newStewardCli)
@@ -36,3 +36,13 @@ def testStewardCanDemoteNode(
         txn = [t for _, t in node.poolLedger.getAllTxn()][-1]
         assert txn[TARGET_NYM] == newNodeVals['newNodeIdr']
         assert SERVICES in txn[DATA] and txn[DATA][SERVICES] == []
+
+    newNodeVals['newNodeData'][SERVICES] = [VALIDATOR]
+
+    do('send NODE dest={newNodeIdr} data={newNodeData}',
+       mapper=newNodeVals, expect=NODE_REQUEST_COMPLETED, within=8)
+
+    for node in poolNodesStarted.nodes.values():
+        txn = [t for _, t in node.poolLedger.getAllTxn()][-1]
+        assert txn[TARGET_NYM] == newNodeVals['newNodeIdr']
+        assert SERVICES in txn[DATA] and txn[DATA][SERVICES] == [VALIDATOR]

--- a/sovrin_client/test/cli/test_nym.py
+++ b/sovrin_client/test/cli/test_nym.py
@@ -255,7 +255,7 @@ def testNewKeyChangesWalletsDefaultId(be, do, poolNodesStarted, poolTxnData,
        expect=["Nym {} added".format(idr)])
 
 
-def testSend2NymsSucceedsWhenBatched(
+def test_send_same_nyms_fails_when_batched(
         be, do, poolNodesStarted, newStewardCli):
 
     be(newStewardCli)
@@ -277,6 +277,45 @@ def testSend2NymsSucceedsWhenBatched(
     parameters = {
         'dest': halfKeyIdentifier,
         'verkey': abbrevVerkey
+    }
+
+    do('send GET_NYM dest={dest}',
+        mapper=parameters, expect=CURRENT_VERKEY_FOR_NYM, within=2)
+
+def test_send_different_nyms_succeeds_when_batched(
+        be, do, poolNodesStarted, newStewardCli):
+
+    be(newStewardCli)
+
+    idr_1, verkey_1 = createHalfKeyIdentifierAndAbbrevVerkey()
+    idr_2, verkey_2 = createHalfKeyIdentifierAndAbbrevVerkey()
+
+    parameters = {
+        'dest': idr_1,
+        'verkey': verkey_1
+    }
+
+    newStewardCli.enterCmd("send NYM dest={dest} verkey={verkey}".format(dest=idr_1, verkey=verkey_1))
+
+    parameters = {
+        'dest': idr_2,
+        'verkey': verkey_2
+    }
+
+    do('send NYM dest={dest} verkey={verkey}',
+       mapper=parameters, expect=NYM_ADDED, within=10)
+
+    parameters = {
+        'dest': idr_1,
+        'verkey': verkey_1
+    }
+
+    do('send GET_NYM dest={dest}',
+        mapper=parameters, expect=CURRENT_VERKEY_FOR_NYM, within=2)
+
+    parameters = {
+        'dest': idr_2,
+        'verkey': verkey_2
     }
 
     do('send GET_NYM dest={dest}',

--- a/sovrin_client/test/cli/test_nym.py
+++ b/sovrin_client/test/cli/test_nym.py
@@ -255,7 +255,7 @@ def testNewKeyChangesWalletsDefaultId(be, do, poolNodesStarted, poolTxnData,
        expect=["Nym {} added".format(idr)])
 
 
-def test_send_same_nyms_fails_when_batched(
+def test_send_same_nyms_only_first_gets_written(
         be, do, poolNodesStarted, newStewardCli):
 
     be(newStewardCli)
@@ -263,6 +263,7 @@ def test_send_same_nyms_fails_when_batched(
     halfKeyIdentifier, abbrevVerkey = createHalfKeyIdentifierAndAbbrevVerkey()
     _, anotherAbbrevVerkey = createHalfKeyIdentifierAndAbbrevVerkey()
 
+    # request 1
     newStewardCli.enterCmd("send NYM {dest}={nym} verkey={verkey}".
             format(dest=TARGET_NYM, nym=halfKeyIdentifier, verkey=abbrevVerkey))
 
@@ -271,6 +272,10 @@ def test_send_same_nyms_fails_when_batched(
         'verkey': anotherAbbrevVerkey
     }
 
+    # "enterCmd" does not immediately send to server, second request with same NYM
+    # and different verkey should not get written to ledger.
+
+    # request 2
     do('send NYM dest={dest} verkey={verkey}',
        mapper=parameters, expect=NYM_ADDED, within=10)
 
@@ -279,6 +284,7 @@ def test_send_same_nyms_fails_when_batched(
         'verkey': abbrevVerkey
     }
 
+    # check that second request didn't write to ledger and first verkey is written
     do('send GET_NYM dest={dest}',
         mapper=parameters, expect=CURRENT_VERKEY_FOR_NYM, within=2)
 
@@ -295,6 +301,7 @@ def test_send_different_nyms_succeeds_when_batched(
         'verkey': verkey_1
     }
 
+    # request 1
     newStewardCli.enterCmd("send NYM dest={dest} verkey={verkey}".format(dest=idr_1, verkey=verkey_1))
 
     parameters = {
@@ -302,6 +309,8 @@ def test_send_different_nyms_succeeds_when_batched(
         'verkey': verkey_2
     }
 
+    # two different nyms, batched, both should be written
+    # request 2
     do('send NYM dest={dest} verkey={verkey}',
        mapper=parameters, expect=NYM_ADDED, within=10)
 

--- a/sovrin_common/auth.py
+++ b/sovrin_common/auth.py
@@ -32,11 +32,11 @@ class Authoriser:
             {r: [OWNER] for r in ValidRoles},
         '{}_services__[VALIDATOR]'.format(NODE):
             {STEWARD: [OWNER, ]},
-        # INDY-410 - steward allowed to suspend its validator
+        # INDY-410 - steward allowed to demote/promote its validator
         '{}_services_[VALIDATOR]_[]'.format(NODE):
             {TRUSTEE: [], STEWARD: [OWNER, ]},
         '{}_services_[]_[VALIDATOR]'.format(NODE):
-            {TRUSTEE: []},
+            {TRUSTEE: [], STEWARD: [OWNER, ]},
         '{}_node_ip_<any>_<any>'.format(NODE):
             {STEWARD: [OWNER, ]},
         '{}_node_port_<any>_<any>'.format(NODE):

--- a/sovrin_node/persistence/idr_cache.py
+++ b/sovrin_node/persistence/idr_cache.py
@@ -73,8 +73,8 @@ class IdrCache:
         else:
             # Looking for uncommitted values, iterating over `currentBatchOps and unCommitted`
             # in reverse to get the latest value
-            for iter, cache in reversed(self.currentBatchOps):
-                if iter == idr.decode():
+            for key, cache in reversed(self.currentBatchOps):
+                if key == idr.decode():
                     value = cache
                     ta, iv, r = self.unpackIdrValue(value)
                     return ta, iv, r

--- a/sovrin_node/persistence/idr_cache.py
+++ b/sovrin_node/persistence/idr_cache.py
@@ -73,10 +73,12 @@ class IdrCache:
         else:
             # Looking for uncommitted values, iterating over `currentBatchOps and unCommitted`
             # in reverse to get the latest value
-            for _, cache in reversed(self.currentBatchOps):
-                if idr in cache:
-                    value = cache[idr]
-                    break;
+            for iter, cache in reversed(self.currentBatchOps):
+                if iter == idr.decode():
+                    value = cache
+                    ta, iv, r = self.unpackIdrValue(value)
+                    return ta, iv, r
+
             for _, cache in reversed(self.unCommitted):
                 if idr in cache:
                     value = cache[idr]


### PR DESCRIPTION
Adds second test to verify batches work when NYMs are different and batch fails when NYMs are the same