### PR TITLE
Closes INDY-251, INDY-259

### DIFF
--- a/sovrin_node/server/upgrader.py
+++ b/sovrin_node/server/upgrader.py
@@ -31,23 +31,8 @@ class Upgrader(HasActionQueue):
         return __version__
 
     @staticmethod
-    def isVersionHigher(oldVer, newVer):
-        r = Upgrader.compareVersions(oldVer, newVer)
-        return True if r == 1 else False
-
-    @staticmethod
-    def isVersionSame(oldVer, newVer):
-        r = Upgrader.compareVersions(oldVer, newVer)
-        return True if r == 0 else False
-
-    @staticmethod
-    def isVersionLower(oldVer, newVer):
-        r = Upgrader.compareVersions(oldVer, newVer)
-        return True if r == -1 else False
-
-    @staticmethod
     def is_version_upgradable(old, new, reinstall: bool = False):
-        return Upgrader.isVersionHigher(old, new) or (Upgrader.isVersionSame(old, new) and reinstall)
+        return reinstall or (Upgrader.compareVersions(old, new) != 0)
 
     @staticmethod
     def compareVersions(verA: str, verB: str) -> int:
@@ -73,12 +58,6 @@ class Upgrader(HasActionQueue):
         if lenB > lenA:
             return 1
         return 0
-
-    @staticmethod
-    def versionsDescOrder(versions):
-        "Returns versions ordered in descending order"
-        return sorted(versions,
-                      key=cmp_to_key(Upgrader.compareVersions))
 
     @staticmethod
     def get_upgrade_id(txn):
@@ -325,21 +304,14 @@ class Upgrader(HasActionQueue):
                 when = txn[SCHEDULE][self.nodeId]
                 failTimeout = txn.get(TIMEOUT, self.defaultUpgradeTimeout)
 
-                if self.scheduledUpgrade:
-                    logger.debug("Node '{}' has a scheduled upgrade".format(self.nodeName))
-
-                    if self.isVersionHigher(self.scheduledUpgrade[0], version):
-                        logger.debug("Node '{}' cancels previous upgrade and schedules a new one to {}".
-                                     format(self.nodeName, version))
-                        # If upgrade has been scheduled but for version
-                        # lower than this transaction propose
-                        self._cancelScheduledUpgrade(justification)
-                        self._scheduleUpgrade(version, when, failTimeout, upgrade_id)
-                    return
-
                 if self.is_version_upgradable(currentVersion, version, reinstall):
-                    logger.debug("Node '{}' schedules upgrade to {}".format(self.nodeName, version))
-                    # If no upgrade has been scheduled
+                    logger.info("Node '{}' schedules upgrade to {}".format(self.nodeName, version))
+
+                    if self.scheduledUpgrade:
+                        logger.info("Node '{}' cancels previous upgrade and schedules a new one to {}".
+                                    format(self.nodeName, version))
+                        self._cancelScheduledUpgrade(justification)
+
                     self._scheduleUpgrade(version, when, failTimeout, upgrade_id)
                 return
 

--- a/sovrin_node/test/upgrade/test_pool_upgrade_lower_version.py
+++ b/sovrin_node/test/upgrade/test_pool_upgrade_lower_version.py
@@ -12,13 +12,12 @@ from sovrin_node.test.upgrade.helper import bumpVersion, checkUpgradeScheduled, 
     ensureUpgradeSent
 
 
-def testDoNotScheduleUpgradeForALowerVersion(looper, tconf, nodeSet,
+def testScheduleUpgradeForALowerVersion(looper, tconf, nodeSet,
                                              validUpgrade, trustee,
                                              trusteeWallet):
     """
     A node starts at version 1.2 running has scheduled upgrade for version 1.5
-    but get a txn for upgrade 1.4, it will not schedule it. To upgrade to 1.4,
-    send cancel for 1.5
+    but get a txn for upgrade 1.4, it will schedule it and cancel upgrade to 1.5.
     """
     upgr1 = deepcopy(validUpgrade)
 
@@ -33,20 +32,11 @@ def testDoNotScheduleUpgradeForALowerVersion(looper, tconf, nodeSet,
     looper.run(eventually(checkUpgradeScheduled, nodeSet, upgr2[VERSION],
                           retryWait=1, timeout=waits.expectedUpgradeScheduled()))
 
-    # An upgrade for lower version scheduled, the transaction should pass but
-    # the upgrade should not be scheduled
-    ensureUpgradeSent(looper, trustee, trusteeWallet, upgr1)
-    with pytest.raises(AssertionError):
-        looper.run(eventually(checkUpgradeScheduled, nodeSet, upgr1[VERSION],
-                              retryWait=1, timeout=waits.expectedUpgradeScheduled()))
-
-    # Cancel the upgrade with higher version
-    upgr3 = deepcopy(upgr2)
-    upgr3[ACTION] = CANCEL
-    ensureUpgradeSent(looper, trustee, trusteeWallet, upgr3)
-
-    # Now we can schedule an upgrade to the lower version
-    upgr1[NAME] = randomString(3)
+    # An upgrade for lower version scheduled, the transaction should pass and
+    # the upgrade should be scheduled
     ensureUpgradeSent(looper, trustee, trusteeWallet, upgr1)
     looper.run(eventually(checkUpgradeScheduled, nodeSet, upgr1[VERSION],
                           retryWait=1, timeout=waits.expectedUpgradeScheduled()))
+
+    for node in nodeSet:
+        assert node.upgrader.scheduledUpgrade[0] == upgr1[VERSION]

--- a/sovrin_node/test/upgrade/test_pool_upgrade_lower_version.py
+++ b/sovrin_node/test/upgrade/test_pool_upgrade_lower_version.py
@@ -37,6 +37,3 @@ def testScheduleUpgradeForALowerVersion(looper, tconf, nodeSet,
     ensureUpgradeSent(looper, trustee, trusteeWallet, upgr1)
     looper.run(eventually(checkUpgradeScheduled, nodeSet, upgr1[VERSION],
                           retryWait=1, timeout=waits.expectedUpgradeScheduled()))
-
-    for node in nodeSet:
-        assert node.upgrader.scheduledUpgrade[0] == upgr1[VERSION]

--- a/sovrin_node/test/upgrade/test_upgrader.py
+++ b/sovrin_node/test/upgrade/test_upgrader.py
@@ -3,12 +3,10 @@ from sovrin_node.server.upgrader import Upgrader
 
 
 def testVersions():
-    assert Upgrader.isVersionHigher('0.0.5', '0.0.6')
-    assert not Upgrader.isVersionHigher('0.0.9', '0.0.8')
-    assert Upgrader.isVersionHigher('0.0.9', '0.1.0')
-    assert Upgrader.isVersionHigher('0.20.30', '1.0.0')
-    assert Upgrader.isVersionHigher('1.3.19', '1.3.20')
-    versions = ['0.0.1', '0.10.11', '0.0.10', '0.0.2',
-                '1.9.0', '9.10.0', '9.1.0']
-    assert Upgrader.versionsDescOrder(versions) == \
-           ['9.10.0', '9.1.0', '1.9.0', '0.10.11', '0.0.10', '0.0.2', '0.0.1']
+    assert Upgrader.compareVersions('0.0.5', '0.0.6') == 1
+    assert Upgrader.compareVersions('0.0.6', '0.0.5') == -1
+    assert Upgrader.compareVersions('0.0.6', '0.0.6') == 0
+    assert not Upgrader.is_version_upgradable('0.0.6', '0.0.6')
+    assert Upgrader.is_version_upgradable('0.0.6', '0.0.6', reinstall=True)
+    assert Upgrader.is_version_upgradable('0.0.5', '0.0.6')
+    assert Upgrader.is_version_upgradable('0.0.6', '0.0.5')

--- a/sovrin_node/test/upgrade/test_upgrader.py
+++ b/sovrin_node/test/upgrade/test_upgrader.py
@@ -2,11 +2,17 @@
 from sovrin_node.server.upgrader import Upgrader
 
 
+def comparator_test(lower_versrion, higher_version):
+    assert Upgrader.compareVersions(lower_versrion, higher_version) == 1
+    assert Upgrader.compareVersions(higher_version, lower_versrion) == -1
+    assert Upgrader.compareVersions(higher_version, higher_version) == 0
+    assert not Upgrader.is_version_upgradable(higher_version, higher_version)
+    assert Upgrader.is_version_upgradable(higher_version, higher_version, reinstall=True)
+    assert Upgrader.is_version_upgradable(lower_versrion, higher_version)
+    assert Upgrader.is_version_upgradable(higher_version, lower_versrion)
+
+
 def testVersions():
-    assert Upgrader.compareVersions('0.0.5', '0.0.6') == 1
-    assert Upgrader.compareVersions('0.0.6', '0.0.5') == -1
-    assert Upgrader.compareVersions('0.0.6', '0.0.6') == 0
-    assert not Upgrader.is_version_upgradable('0.0.6', '0.0.6')
-    assert Upgrader.is_version_upgradable('0.0.6', '0.0.6', reinstall=True)
-    assert Upgrader.is_version_upgradable('0.0.5', '0.0.6')
-    assert Upgrader.is_version_upgradable('0.0.6', '0.0.5')
+    comparator_test('0.0.5', '0.0.6')
+    comparator_test('0.1.2', '0.2.6')
+    comparator_test('1.10.2', '2.0.6')


### PR DESCRIPTION
Bug Fixed: POOL_UPGRADE only installs the latest build. You are not able to specify a version other than the latest to upgrade to.

Feature Added: POOL_UPGRADE should support downgrades