### PR TITLE
fix pointers to old (bad) instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Use project name `INDY`.
 Join us on [Jira's Rocket.Chat](chat.hyperledger.org) at `#indy` to discuss.
 
 Today, documentation for Indy is sparse. Most materials that exist were written for Sovrin. Therefore,
-we recommend that developers should explore Sovrin's [Getting Started Guide](https://github.com/sovrin-foundation/sovrin-client/blob/master/getting-started.md) to learn about Indy Node basics. In the future, documentation
+we recommend that developers should explore Sovrin's [Getting Started Guide](getting-started.md) to learn about Indy Node basics. In the future, documentation
 will be part of [indy-sdk](https://github.com/hyperledger/indy-sdk).
 
-Have a look at [Setup Instructions](https://github.com/sovrin-foundation/sovrin-client/blob/master/setup.md)
+Have a look at [Setup Instructions](setup.md)
 to understand how to work with the code. Note that setup instructions may change often.
 
 ## Contributions

--- a/getting-started.md
+++ b/getting-started.md
@@ -813,7 +813,7 @@ Response from Thrift Bank (69.9 ms):
 ```
 ## Explore the Code
 
-Now that you've had a chance to see how Sovrin works from the outside, perhaps you'd like to see how it works underneath, from code? If so, please navigate to [Simulating Getting Started in an Event Loop](https://github.com/sovrin-foundation/sovrin-client/blob/master/sovrin_client/test/training/test_getting_started_guide.py).
+Now that you've had a chance to see how Sovrin works from the outside, perhaps you'd like to see how it works underneath, from code? If so, please navigate to [Simulating Getting Started in an Event Loop](sovrin_client/test/training/test_getting_started_guide.py).
 You may need to be signed into Github to view this link.
 
 # Appendix

--- a/setup.md
+++ b/setup.md
@@ -185,7 +185,7 @@ on what type of development environment you have. In particular, we
 think you will have a bumpy ride on windows. We are working on improving
 these instructions.
 
-Developers should explore the [Getting Started Guide](https://github.com/sovrin-foundation/sovrin-client/blob/master/getting-started.md) to learn how Sovrin works.
+Developers should explore the [Getting Started Guide](getting-started.md) to learn how Sovrin works.
 
 The Sovrin codebase makes extensive use of coroutines and the async/await keywords in
 Python, and as such, requires Python version 3.5.0 or later. Plenum also


### PR DESCRIPTION
Note that there are also references to sovrin-foundation/sovrin-common which maybe should now be hyperledger/indy-common.