### PR TITLE
Improve packaging before supporting CentOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
 	sh "docker volume rm $volumeName"
     }
     dir('build-scripts/ubuntu-1604') {
-        sh "./build-$name-docker.sh $sourcePath $releaseVersion"
+        sh "./build-$name-docker.sh \"$sourcePath\" \"$releaseVersion\""
         sh "./build-3rd-parties-docker.sh"
     }
     return "$volumeName"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,12 +74,13 @@ def commonTestUbuntu = {
 
 def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     def volumeName = "$name-deb-u1604"
+    if ("${BRANCH_NAME}" != '' && "${BRANCH_NAME}" != 'master') volumeName = "${volumeName}.${BRANCH_NAME}"
     if (sh(script: "docker volume ls -q | grep -q '^$volumeName\$'", returnStatus: true) == 0) {
 	sh "docker volume rm $volumeName"
     }
     dir('build-scripts/ubuntu-1604') {
-        sh "./build-$name-docker.sh \"$sourcePath\" \"$releaseVersion\""
-        sh "./build-3rd-parties-docker.sh"
+        sh "./build-$name-docker.sh \"$sourcePath\" $releaseVersion $volumeName"
+        sh "./build-3rd-parties-docker.sh $volumeName"
     }
     return "$volumeName"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,9 @@ def commonTestUbuntu = {
 
 def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     def volumeName = "$name-deb-u1604"
-    sh "docker volume rm -f $volumeName"
+    if (sh(script: "docker volume ls -q | grep -q '^$volumeName\$'", returnStatus: true) == 0) {
+	sh "docker volume rm $volumeName"
+    }
     dir('build-scripts/ubuntu-1604') {
         sh "./build-$name-docker.sh $sourcePath $releaseVersion"
         sh "./build-3rd-parties-docker.sh"

--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -74,10 +74,13 @@ def commonTestUbuntu = {
 
 def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     def volumeName = "$name-deb-u1604"
-    sh "docker volume rm -f $volumeName"
+    if ("${BRANCH_NAME}" != '' && "${BRANCH_NAME}" != 'master') volumeName = "${volumeName}.${BRANCH_NAME}"
+    if (sh(script: "docker volume ls -q | grep -q '^$volumeName\$'", returnStatus: true) == 0) {
+	sh "docker volume rm $volumeName"
+    }
     dir('build-scripts/ubuntu-1604') {
-        sh "./build-$name-docker.sh $sourcePath $releaseVersion"
-        sh "./build-3rd-parties-docker.sh"
+        sh "./build-$name-docker.sh \"$sourcePath\" $releaseVersion $volumeName"
+        sh "./build-3rd-parties-docker.sh $volumeName"
     }
     return "$volumeName"
 }

--- a/build-scripts/ubuntu-1604/build-3rd-parties-docker.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties-docker.sh
@@ -3,15 +3,15 @@
 set -x
 set -e
 
-if [ -z $1 ]; then
+if [ -z "$2" ]; then
     CMD="/root/build-3rd-parties.sh /output"
 else
-    CMD="$1"
+    CMD="$2"
 fi
 
 PKG_NAME=indy-node
 IMAGE_NAME="${PKG_NAME}-build-u1604"
-OUTPUT_VOLUME_NAME="${PKG_NAME}-deb-u1604"
+OUTPUT_VOLUME_NAME="$1"
 
 docker build -t "${PKG_NAME}-build-u1604" -f Dockerfile .
 docker volume create --name "${OUTPUT_VOLUME_NAME}"

--- a/build-scripts/ubuntu-1604/build-3rd-parties-docker.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties-docker.sh
@@ -6,19 +6,19 @@ set -e
 if [ -z $1 ]; then
     CMD="/root/build-3rd-parties.sh /output"
 else
-    CMD=$1
+    CMD="$1"
 fi
 
 PKG_NAME=indy-node
-IMAGE_NAME=${PKG_NAME}-build-u1604
-OUTPUT_VOLUME_NAME=${PKG_NAME}-deb-u1604
+IMAGE_NAME="${PKG_NAME}-build-u1604"
+OUTPUT_VOLUME_NAME="${PKG_NAME}-deb-u1604"
 
-docker build -t ${PKG_NAME}-build-u1604 -f Dockerfile .
-docker volume create --name ${OUTPUT_VOLUME_NAME}
+docker build -t "${PKG_NAME}-build-u1604" -f Dockerfile .
+docker volume create --name "${OUTPUT_VOLUME_NAME}"
 
 docker run \
     -i \
     --rm \
-    -v ${OUTPUT_VOLUME_NAME}:/output \
-    ${IMAGE_NAME} \
+    -v "${OUTPUT_VOLUME_NAME}:/output" \
+    "${IMAGE_NAME}" \
     $CMD

--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -3,22 +3,22 @@
 set -e
 set -x
 
-OUTPUT_PATH=${1:-.}
+OUTPUT_PATH="${1:-.}"
 
 function build_from_pypi {
-    PACKAGE_NAME=$1
+    PACKAGE_NAME="$1"
 
-    if [ -z $2 ]; then
+    if [ -z "$2" ]; then
         PACKAGE_VERSION=""
     else
         PACKAGE_VERSION="==$2"
     fi
-    POSTINST_TMP=postinst-${PACKAGE_NAME}
-    PREREM_TMP=prerm-${PACKAGE_NAME}
-    cp postinst ${POSTINST_TMP}
-    cp prerm ${PREREM_TMP}
-    sed -i 's/{package_name}/python3-'${PACKAGE_NAME}'/' ${POSTINST_TMP}
-    sed -i 's/{package_name}/python3-'${PACKAGE_NAME}'/' ${PREREM_TMP}
+    POSTINST_TMP="postinst-${PACKAGE_NAME}"
+    PREREM_TMP="prerm-${PACKAGE_NAME}"
+    cp postinst "${POSTINST_TMP}"
+    cp prerm "${PREREM_TMP}"
+    sed -i "s/{package_name}/python3-${PACKAGE_NAME}/" "${POSTINST_TMP}"
+    sed -i "s/{package_name}/python3-${PACKAGE_NAME}/" "${PREREM_TMP}"
 
     fpm --input-type "python" \
         --output-type "deb" \
@@ -29,13 +29,13 @@ function build_from_pypi {
         --exclude "*.pyc" \
         --exclude "*.pyo" \
         --maintainer "Hyperledger <hyperledger-indy@lists.hyperledger.org>" \
-        --after-install ${POSTINST_TMP} \
-        --before-remove ${PREREM_TMP} \
-        --package ${OUTPUT_PATH} \
-        ${PACKAGE_NAME}${PACKAGE_VERSION}
+        --after-install "${POSTINST_TMP}" \
+        --before-remove "${PREREM_TMP}" \
+        --package "${OUTPUT_PATH}" \
+        "${PACKAGE_NAME}${PACKAGE_VERSION}"
 
-    rm ${POSTINST_TMP}
-    rm ${PREREM_TMP}
+    rm "${POSTINST_TMP}"
+    rm "${PREREM_TMP}"
 }
 
 # build 3rd parties:

--- a/build-scripts/ubuntu-1604/build-indy-node-docker.sh
+++ b/build-scripts/ubuntu-1604/build-indy-node-docker.sh
@@ -4,17 +4,17 @@ PKG_SOURCE_PATH="$1"
 VERSION="$2"
 PKG_NAME=indy-node
 IMAGE_NAME="${PKG_NAME}-build-u1604"
-OUTPUT_VOLUME_NAME="${PKG_NAME}-deb-u1604"
+OUTPUT_VOLUME_NAME="$3"
 
 if [[ (-z "${PKG_SOURCE_PATH}") || (-z "${VERSION}") ]]; then
     echo "Usage: $0 <path-to-package-sources> <version>"
     exit 1;
 fi
 
-if [ -z "$3" ]; then
+if [ -z "$4" ]; then
     CMD="/root/build-${PKG_NAME}.sh /input ${VERSION} /output"
 else
-    CMD="$3"
+    CMD="$4"
 fi
 
 docker build -t "${IMAGE_NAME}" -f Dockerfile .

--- a/build-scripts/ubuntu-1604/build-indy-node-docker.sh
+++ b/build-scripts/ubuntu-1604/build-indy-node-docker.sh
@@ -1,31 +1,31 @@
 #!/bin/bash -xe
 
-PKG_SOURCE_PATH=$1
-VERSION=$2
+PKG_SOURCE_PATH="$1"
+VERSION="$2"
 PKG_NAME=indy-node
-IMAGE_NAME=${PKG_NAME}-build-u1604
-OUTPUT_VOLUME_NAME=${PKG_NAME}-deb-u1604
+IMAGE_NAME="${PKG_NAME}-build-u1604"
+OUTPUT_VOLUME_NAME="${PKG_NAME}-deb-u1604"
 
-if [[ (-z ${PKG_SOURCE_PATH}) || (-z ${VERSION}) ]]; then
+if [[ (-z "${PKG_SOURCE_PATH}") || (-z "${VERSION}") ]]; then
     echo "Usage: $0 <path-to-package-sources> <version>"
     exit 1;
 fi
 
-if [ -z $3 ]; then
-    CMD="/root/build-"${PKG_NAME}".sh /input ${VERSION} /output"
+if [ -z "$3" ]; then
+    CMD="/root/build-${PKG_NAME}.sh /input ${VERSION} /output"
 else
-    CMD=$3
+    CMD="$3"
 fi
 
-docker build -t ${IMAGE_NAME} -f Dockerfile .
-docker volume create --name ${OUTPUT_VOLUME_NAME}
+docker build -t "${IMAGE_NAME}" -f Dockerfile .
+docker volume create --name "${OUTPUT_VOLUME_NAME}"
 
 docker run \
     -i \
     --rm \
-    -v ${PKG_SOURCE_PATH}:/input \
-    -v ${OUTPUT_VOLUME_NAME}:/output \
-    -e PKG_NAME=${PKG_NAME} \
-    ${IMAGE_NAME} \
+    -v "${PKG_SOURCE_PATH}:/input" \
+    -v "${OUTPUT_VOLUME_NAME}:/output" \
+    -e PKG_NAME="${PKG_NAME}" \
+    "${IMAGE_NAME}" \
     $CMD
 

--- a/build-scripts/ubuntu-1604/build-indy-node.sh
+++ b/build-scripts/ubuntu-1604/build-indy-node.sh
@@ -1,21 +1,21 @@
 #!/bin/bash -xe
 
-INPUT_PATH=$1
-VERSION=$2
-OUTPUT_PATH=${3:-.}
+INPUT_PATH="$1"
+VERSION="$2"
+OUTPUT_PATH="${3:-.}"
 
 PACKAGE_NAME=indy-node
 
 # copy the sources to a temporary folder
-TMP_DIR=$(mktemp -d)
-cp -r ${INPUT_PATH}/. ${TMP_DIR}
+TMP_DIR="$(mktemp -d)"
+cp -r "${INPUT_PATH}/." "${TMP_DIR}"
 
 # prepare the sources
-cd ${TMP_DIR}/build-scripts/ubuntu-1604
-./prepare-package.sh ${TMP_DIR} ${VERSION}
+cd "${TMP_DIR}/build-scripts/ubuntu-1604"
+./prepare-package.sh "${TMP_DIR}" "${VERSION}"
 
 
-sed -i 's/{package_name}/'${PACKAGE_NAME}'/' "prerm"
+sed -i "s/{package_name}/${PACKAGE_NAME}/" "prerm"
 
 fpm --input-type "python" \
     --output-type "deb" \
@@ -31,8 +31,8 @@ fpm --input-type "python" \
     --before-install "preinst_node" \
     --after-install "postinst_node" \
     --before-remove "prerm" \
-    --name ${PACKAGE_NAME} \
-    --package ${OUTPUT_PATH} \
-    ${TMP_DIR}
+    --name "${PACKAGE_NAME}" \
+    --package "${OUTPUT_PATH}" \
+    "${TMP_DIR}"
 
-rm -rf ${TMP_DIR}
+rm -rf "${TMP_DIR}"


### PR DESCRIPTION
- Work around missing "docker volume rm --force" option in older API (< 1.25). So it also works with docker 1.12 provided with CentOS 7 (should not hurt).
- Quote shell variables to support space in paths (always good).
- Support parallel docker builds by adding suffix to volumes in case of multi-branch pipeline (should not change anything for single-branch).

REM: I'll PR similar improvements in sovrin, plenum and anoncreds repos if this one is merged.