### PR TITLE
README_update2 Adds a link to the Hyperledger Wiki-Indy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ![logo](collateral/logos/indy-logo.png)
 
+## Before you Continue
+
+If you haven't done so already, please visit the main resource for all things "Indy" to get acquainted with the code base, helpful resources, and up-to-date information: [Hyperledger Wiki-Indy](https://wiki.hyperledger.org/projects/indy).
+
 ## Indy Node
 
 This codebase embodies all the functionality to run nodes--validators and/or observers


### PR DESCRIPTION
Adds a link to the Hyperledger Wiki-Indy page within the README.md file
in an effort to consolidate and encourage the wiki page to be the
main "hub" starting point for the Indy documentation.

Signed-off-by: TechWritingWhiz <TechWritingWhiz@gmail.com>