### PR TITLE
Point to the stable branch of the evernym repo

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -56,7 +56,7 @@ For this guide, however, we’ll be using a command - line interface instead of 
 ## Install Sovrin
 You can install a Sovrin test network in one of several ways:
 
- - **Automated VM Creation** [Create virtual machines](https://github.com/evernym/sovrin-environments/blob/master/vagrant/training/vb-multi-vm/TestSovrinClusterSetup.md) using VirtualBox and Vagrant.
+ - **Automated VM Creation** [Create virtual machines](https://github.com/evernym/sovrin-environments/blob/stable/vagrant/training/vb-multi-vm/TestSovrinClusterSetup.md) using VirtualBox and Vagrant.
 
  - **Coming soon:** Use client side docker images to make it easy for you to play with Sovrin.
 


### PR DESCRIPTION
These stable branch instructions should point to the stable branch instructions of the evernym repo to be in sync.  Changed the "create virtual machines" link to https://github.com/evernym/sovrin-environments/blob/stable/vagrant/training/vb-multi-vm/TestSovrinClusterSetup.md.