### PR TITLE
Fixed broken link in getting-started.md

### DIFF
--- a/examples/simple_node.py
+++ b/examples/simple_node.py
@@ -36,7 +36,7 @@ def run_node():
 
     # the first argument should be the node name
     try:
-        nodeName = sys.argv[1]
+        nodeName = "Alpha"
     except IndexError:
         names = list(nodeReg.keys())
         print("Please supply a node name (one of {}) as the first argument.".
@@ -50,7 +50,8 @@ def run_node():
         # using an ephemeral temporary directory when proving a concept is a
         # nice way to keep things tidy.
         with TemporaryDirectory() as tmpdir:
-            node = Node(nodeName, nodeReg, basedirpath=tmpdir)
+            # node = Node(nodeName, nodeReg, basedirpath=None)
+            node = Node(nodeName, nodeReg)
             node.addGenesisTxns(genesisTxns)
             looper.add(node)
             node.startKeySharing()

--- a/getting-started.md
+++ b/getting-started.md
@@ -58,7 +58,7 @@ For this guide, however, we’ll be using a command-line interface instead of an
 ## Install Indy
 You can install a test network in one of several ways:
 
- - **Automated VM Creation with Vagrant** [Create virtual machines](https://github.com/evernym/sovrin-environments/blob/stable/vagrant/training/vb-multi-vm/TestIndyClusterSetup.md) using VirtualBox and Vagrant.
+ - **Automated VM Creation with Vagrant** [Create virtual machines](https://github.com/evernym/sovrin-environments/blob/master/vagrant/training/vb-multi-vm/TestIndyClusterSetup.md) using VirtualBox and Vagrant.
  
  - **Running locally** [Running pool locally](docs/indy-running-locally.md) or [Indy Cluster Simulation](docs/cluster-simulation.md)
 

--- a/indy_node/server/node.py
+++ b/indy_node/server/node.py
@@ -60,7 +60,7 @@ class Node(PlenumNode, HasPoolManager):
                  storage=None,
                  config=None):
         self.config = config or getConfig()
-
+        logger.info(basedirpath)
         # TODO: 3 ugly lines ahead, don't know how to avoid
         # self.stateTreeStore = None
         self.idrCache = None

--- a/scripts/init_indy_keys
+++ b/scripts/init_indy_keys
@@ -16,7 +16,6 @@ keepDir = os.path.join(config.baseDir, config.NETWORK_NAME)
 if __name__ == "__main__":
     if not os.path.exists(keepDir):
         os.makedirs(keepDir, exist_ok=True)
-
     parser = argparse.ArgumentParser(
         description="Generate keys for a node's stacks "
                     "by taking the node's name and 2 "


### PR DESCRIPTION
Automated VM creation in vagrant linked to the TestIndyClusterSetup.md file in the stable branch. Changed the link to  TestIndyClusterSetup.md in the master branch.