### PR TITLE
INDY-799: Fix sending NODE_UPGRADE txn after Node is upgraded

### DIFF
--- a/indy_node/server/upgrader.py
+++ b/indy_node/server/upgrader.py
@@ -101,12 +101,7 @@ class Upgrader(HasActionQueue):
         self.retry_timeout = 5
         self.retry_limit = 3
 
-        # whether upgrade was started before the Node restarted,
-        # that is whether Upgrade Log contains STARTED event
-        self._upgrade_started = self._is_upgrade_started()
-        if self._upgrade_started:
-            # append SUCCESS or FAIL to the Upgrade Lof
-            self._update_upgrade_log_for_started_upgrade()
+        self.process_upgrade_log_for_first_run()
 
         HasActionQueue.__init__(self)
 
@@ -116,6 +111,14 @@ class Upgrader(HasActionQueue):
 
     def service(self):
         return self._serviceActions()
+
+    def process_upgrade_log_for_first_run(self):
+        # whether upgrade was started before the Node restarted,
+        # that is whether Upgrade Log contains STARTED event
+        self._upgrade_started = self._is_upgrade_started()
+        if self._upgrade_started:
+            # append SUCCESS or FAIL to the Upgrade Lof
+            self._update_upgrade_log_for_started_upgrade()
 
     def _is_upgrade_started(self):
         if not self.lastUpgradeEventInfo:

--- a/indy_node/server/upgrader.py
+++ b/indy_node/server/upgrader.py
@@ -32,7 +32,7 @@ class Upgrader(HasActionQueue):
     @staticmethod
     def is_version_upgradable(old, new, reinstall: bool = False):
         return (Upgrader.compareVersions(old, new) > 0) \
-               or (Upgrader.compareVersions(old, new) == 0) and reinstall
+            or (Upgrader.compareVersions(old, new) == 0) and reinstall
 
     @staticmethod
     def compareVersions(verA: str, verB: str) -> int:
@@ -150,7 +150,7 @@ class Upgrader(HasActionQueue):
         self._notifier.sendMessageUponNodeUpgradeComplete(
             "Upgrade of node '{}' to version {} scheduled on {} "
             " with upgrade_id {} completed successfully"
-                .format(self.nodeName, version, when, upgrade_id))
+            .format(self.nodeName, version, when, upgrade_id))
 
     def should_notify_about_upgrade_result(self):
         # do not rely on NODE_UPGRADE txn in config ledger, since in some cases (for example, when
@@ -220,8 +220,9 @@ class Upgrader(HasActionQueue):
 
             # searching for CANCEL for this upgrade submitted after START txn
             last_pool_upgrade_txn_cancel = self.get_upgrade_txn(
-                lambda txn: txn[TXN_TYPE] == POOL_UPGRADE and txn[ACTION] == CANCEL and
-                            txn[VERSION] == last_pool_upgrade_txn_start[VERSION],
+                lambda txn:
+                txn[TXN_TYPE] == POOL_UPGRADE and txn[ACTION] == CANCEL and
+                txn[VERSION] == last_pool_upgrade_txn_start[VERSION],
                 start_no=last_pool_upgrade_txn_seq_no + 1)
             if last_pool_upgrade_txn_cancel:
                 logger.info('{} found upgrade CANCEL txn {}'.format(
@@ -337,8 +338,7 @@ class Upgrader(HasActionQueue):
             return
 
         if action == CANCEL:
-            if self.scheduledUpgrade and \
-                            self.scheduledUpgrade[0] == version:
+            if self.scheduledUpgrade and self.scheduledUpgrade[0] == version:
                 self._cancelScheduledUpgrade(justification)
                 logger.info("Node '{}' cancels upgrade to {}".format(
                     self.nodeName, version))
@@ -368,8 +368,8 @@ class Upgrader(HasActionQueue):
         now = datetime.utcnow().replace(tzinfo=dateutil.tz.tzutc())
 
         self._notifier.sendMessageUponNodeUpgradeScheduled(
-            "Upgrade of node '{}' to version {} has been scheduled on {}"
-                .format(self.nodeName, version, when))
+            "Upgrade of node '{}' to version {} has been scheduled on {}".format(
+                self.nodeName, version, when))
         self._upgradeLog.appendScheduled(when, version, upgrade_id)
 
         callAgent = partial(self._callUpgradeAgent, when,
@@ -412,8 +412,8 @@ class Upgrader(HasActionQueue):
             self._upgradeLog.appendCancelled(when, version, upgrade_id)
             self._notifier.sendMessageUponPoolUpgradeCancel(
                 "Upgrade of node '{}' to version {} "
-                "has been cancelled due to {}"
-                    .format(self.nodeName, version, why))
+                "has been cancelled due to {}".format(
+                    self.nodeName, version, why))
 
     def _unscheduleUpgrade(self):
         """

--- a/indy_node/test/upgrade/helper.py
+++ b/indy_node/test/upgrade/helper.py
@@ -163,6 +163,15 @@ def check_node_sent_acknowledges_upgrade(
             retryWait=1,
             timeout=timeout))
 
+def check_node_do_not_sent_acknowledges_upgrade(
+        looper, node_set, node_ids, allowed_actions: List, ledger_size, expected_version):
+    '''
+    Check that each node has sent NODE_UPGRADE txn with the specified actions
+    '''
+    looper.runFor(5)
+    check_ledger_after_upgrade(node_set, allowed_actions,
+                               ledger_size, expected_version,
+                               node_ids)
 
 def check_ledger_after_upgrade(
         node_set,

--- a/indy_node/test/upgrade/helper.py
+++ b/indy_node/test/upgrade/helper.py
@@ -163,6 +163,13 @@ def check_node_sent_acknowledges_upgrade(
             retryWait=1,
             timeout=timeout))
 
+
+def emulate_restart_pool_for_upgrade(nodes):
+    for node in nodes:
+        node.upgrader = node.getUpgrader()
+        node.acknowledge_upgrade()
+
+
 def check_node_do_not_sent_acknowledges_upgrade(
         looper, node_set, node_ids, allowed_actions: List, ledger_size, expected_version):
     '''
@@ -171,7 +178,7 @@ def check_node_do_not_sent_acknowledges_upgrade(
     looper.runFor(5)
     check_ledger_after_upgrade(node_set, allowed_actions,
                                ledger_size, expected_version,
-                               node_ids)
+                               node_ids=node_ids)
 
 def check_ledger_after_upgrade(
         node_set,
@@ -182,7 +189,7 @@ def check_ledger_after_upgrade(
         node_ids=None):
     versions = set()
     for node in node_set:
-        print(len(node.configLedger))
+        # print(len(node.configLedger))
         assert len(node.configLedger) == ledger_size
         ids = set()
         for _, txn in node.configLedger.getAllTxn():

--- a/indy_node/test/upgrade/helper.py
+++ b/indy_node/test/upgrade/helper.py
@@ -221,7 +221,8 @@ def check_no_loop(nodeSet, event):
                                                 node.upgrader.scheduledUpgrade[2])
         node.notify_upgrade_start()
         # mimicking upgrader's initialization after restart
-        node.upgrader.check_upgrade_succeeded()
+        node.upgrader.process_upgrade_log_for_first_run()
+
         node.upgrader.scheduledUpgrade = None
         assert node.upgrader._upgradeLog.lastEvent[1] == event
         # mimicking node's catchup after restart

--- a/indy_node/test/upgrade/helper.py
+++ b/indy_node/test/upgrade/helper.py
@@ -3,7 +3,7 @@ from stp_core.loop.eventually import eventually
 from plenum.test.helper import waitForSufficientRepliesForRequests
 from plenum.test import waits as plenumWaits
 from plenum.common.types import f
-from plenum.common.constants import TXN_TYPE, DATA
+from plenum.common.constants import TXN_TYPE, DATA, VERSION
 from indy_common.constants import NODE_UPGRADE, ACTION
 from indy_client.client.wallet.upgrade import Upgrade
 from indy_node.server.upgrader import Upgrader
@@ -143,34 +143,23 @@ def populate_log_with_upgrade_events(
         log.appendStarted(when, version, randomString(10))
 
 
-def check_node_set_acknowledges_upgrade(
-        looper, node_set, node_ids, allowed_actions: List, version: Tuple[str, str, str]):
+def check_node_sent_acknowledges_upgrade(
+        looper, node_set, node_ids, allowed_actions: List, ledger_size, expected_version):
+    '''
+    Check that each node has sent NODE_UPGRADE txn with the specified actions
+    '''
     check = functools.partial(
         check_ledger_after_upgrade,
         node_set,
         allowed_actions,
+        ledger_size,
+        expected_version,
         node_ids=node_ids)
 
-    for node in node_set:
-        node.upgrader.scheduledUpgrade = (version,
-                                          datetime.utcnow().replace(tzinfo=dateutil.tz.tzutc()),
-                                          randomString(10))
-        node.notify_upgrade_start()
-        node.upgrader.scheduledUpgrade = None
-
     timeout = plenumWaits.expectedTransactionExecutionTime(len(node_set))
-    looper.run(eventually(functools.partial(
-        check, ledger_size=len(node_set)), retryWait=1, timeout=timeout))
-
-    for node in node_set:
-        node.acknowledge_upgrade()
-
     looper.run(
         eventually(
-            functools.partial(
-                check,
-                ledger_size=2 *
-                len(node_set)),
+            check,
             retryWait=1,
             timeout=timeout))
 
@@ -179,8 +168,10 @@ def check_ledger_after_upgrade(
         node_set,
         allowed_actions,
         ledger_size,
-        node_ids=None,
-        allowed_txn_types=[NODE_UPGRADE]):
+        expected_version,
+        allowed_txn_types=[NODE_UPGRADE],
+        node_ids=None):
+    versions = set()
     for node in node_set:
         print(len(node.configLedger))
         assert len(node.configLedger) == ledger_size
@@ -191,12 +182,19 @@ def check_ledger_after_upgrade(
             data = txn
             if type == NODE_UPGRADE:
                 data = txn[DATA]
+
+            assert data[ACTION]
             assert data[ACTION] in allowed_actions
             ids.add(txn[f.IDENTIFIER.nm])
+
+            assert data[VERSION]
+            versions.add(data[VERSION])
         ids.add(node.id)
 
         if node_ids:
             assert ids == set(node_ids)
+    assert len(versions) == 1
+    assert list(versions)[0] == expected_version
 
 
 def check_no_loop(nodeSet, event):

--- a/indy_node/test/upgrade/test_node_upgrade.py
+++ b/indy_node/test/upgrade/test_node_upgrade.py
@@ -5,7 +5,8 @@ from indy_node.server.upgrade_log import UpgradeLog
 from stp_core.loop.eventually import eventually
 from indy_common.constants import IN_PROGRESS, COMPLETE
 from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, \
-    check_node_sent_acknowledges_upgrade, check_ledger_after_upgrade, check_node_do_not_sent_acknowledges_upgrade
+    check_node_sent_acknowledges_upgrade, check_ledger_after_upgrade, check_node_do_not_sent_acknowledges_upgrade, \
+    emulate_restart_pool_for_upgrade
 from plenum.test import waits as plenumWaits
 
 whitelist = ['unable to send message']
@@ -54,9 +55,9 @@ def test_node_sent_upgrade_successful_once(looper, nodeSet, nodeIds):
     so that if we restart the node it's not sent again
     '''
     # emulate restart
-    for node in nodeSet:
-        node.acknowledge_upgrade()
+    emulate_restart_pool_for_upgrade(nodeSet)
 
+    # check that config ledger didn't changed (no new txns were sent)
     check_node_do_not_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
                                                 allowed_actions=[COMPLETE],
                                                 ledger_size=len(nodeSet),

--- a/indy_node/test/upgrade/test_node_upgrade.py
+++ b/indy_node/test/upgrade/test_node_upgrade.py
@@ -1,15 +1,18 @@
 import pytest
 
 import indy_node
+from indy_node.server.upgrade_log import UpgradeLog
 from stp_core.loop.eventually import eventually
 from indy_common.constants import IN_PROGRESS, COMPLETE
-from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, check_node_set_acknowledges_upgrade
+from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, \
+    check_node_sent_acknowledges_upgrade
 from plenum.test import waits as plenumWaits
 
 
 whitelist = ['unable to send message']
 # TODO: Implement a client in node
 
+version = indy_node.__metadata__.__version__
 
 @pytest.fixture(scope="module")
 def tdirWithPoolTxns(tdirWithPoolTxns, poolTxnNodeNames, tconf):
@@ -19,20 +22,27 @@ def tdirWithPoolTxns(tdirWithPoolTxns, poolTxnNodeNames, tconf):
         tdirWithPoolTxns,
         poolTxnNodeNames,
         tconf,
-        indy_node.__metadata__.__version__)
+        version)
     return tdirWithPoolTxns
 
 
-def testNodeDetectsUpgradeDone(looper, nodeSet):
-    def check():
-        for node in nodeSet:
-            assert node.upgrader.lastUpgradeEventInfo[2] == indy_node.__metadata__.__version__
+def test_node_detected_upgrade_done(nodeSet):
+    '''
+    Test that each node checks Upgrade Log on startup (after Upgrade restart), and writes SUCCESS to it
+    because the current version equals to the one in Upgrade log.
+    Upgrade log already created START event (see fixture above emulating real upgrade)
+    '''
+    for node in nodeSet:
+        assert node.upgrader.scheduledUpgrade is None
+        assert node.upgrader.lastUpgradeEventInfo[0] == UpgradeLog.UPGRADE_SUCCEEDED
 
-    timeout = plenumWaits.expectedTransactionExecutionTime(len(nodeSet))
-    looper.run(eventually(check, retryWait=1, timeout=timeout))
 
-
-def testSendNodeUpgradeToAllNodes(looper, nodeSet, nodeIds):
-    check_node_set_acknowledges_upgrade(
-        looper, nodeSet, nodeIds, [
-            IN_PROGRESS, COMPLETE], indy_node.__metadata__.__version__)
+def test_node_sent_upgrade_successful(looper, nodeSet, nodeIds):
+    '''
+    Test that each node sends NODE_UPGRADE Success event (because it sees SUCCESS in Upgrade log)
+    Upgrade log already created START event (see fixture above emulating real upgrade)
+    '''
+    check_node_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
+                                         allowed_actions=[COMPLETE],
+                                         ledger_size=len(nodeSet),
+                                         expected_version=version)

--- a/indy_node/test/upgrade/test_node_upgrade_unsuccessful.py
+++ b/indy_node/test/upgrade/test_node_upgrade_unsuccessful.py
@@ -2,7 +2,8 @@ import pytest
 
 from indy_common.constants import FAIL
 from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, \
-    bumpedVersion, check_node_sent_acknowledges_upgrade, check_node_do_not_sent_acknowledges_upgrade
+    bumpedVersion, check_node_sent_acknowledges_upgrade, check_node_do_not_sent_acknowledges_upgrade, \
+    emulate_restart_pool_for_upgrade
 from indy_node.server.upgrade_log import UpgradeLog
 
 INVALID_VERSION = bumpedVersion()
@@ -51,9 +52,9 @@ def test_node_sent_upgrade_unsuccessful_once(looper, nodeSet, nodeIds):
     so that if we restart the node it's not sent again
     '''
     # emulate restart
-    for node in nodeSet:
-        node.acknowledge_upgrade()
+    emulate_restart_pool_for_upgrade(nodeSet)
 
+    # check that config ledger didn't changed (no new txns were sent)
     check_node_do_not_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
                                                 allowed_actions=[FAIL],
                                                 ledger_size=len(nodeSet),

--- a/indy_node/test/upgrade/test_node_upgrade_unsuccessful.py
+++ b/indy_node/test/upgrade/test_node_upgrade_unsuccessful.py
@@ -2,7 +2,7 @@ import pytest
 
 from indy_common.constants import FAIL
 from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, \
-    bumpedVersion, check_node_sent_acknowledges_upgrade
+    bumpedVersion, check_node_sent_acknowledges_upgrade, check_node_do_not_sent_acknowledges_upgrade
 from indy_node.server.upgrade_log import UpgradeLog
 
 INVALID_VERSION = bumpedVersion()
@@ -43,3 +43,18 @@ def test_node_sent_upgrade_fail(looper, nodeSet, nodeIds):
                                          allowed_actions=[FAIL],
                                          ledger_size=len(nodeSet),
                                          expected_version=INVALID_VERSION)
+
+
+def test_node_sent_upgrade_unsuccessful_once(looper, nodeSet, nodeIds):
+    '''
+    Test that each node sends NODE_UPGRADE Fail event only once,
+    so that if we restart the node it's not sent again
+    '''
+    # emulate restart
+    for node in nodeSet:
+        node.acknowledge_upgrade()
+
+    check_node_do_not_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
+                                                allowed_actions=[FAIL],
+                                                ledger_size=len(nodeSet),
+                                                expected_version=INVALID_VERSION)

--- a/indy_node/test/upgrade/test_node_upgrade_unsuccessful.py
+++ b/indy_node/test/upgrade/test_node_upgrade_unsuccessful.py
@@ -1,15 +1,15 @@
 import pytest
 
-from indy_common.constants import IN_PROGRESS, FAIL
-from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, check_node_set_acknowledges_upgrade, \
-    bumpedVersion
+from indy_common.constants import FAIL
+from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, \
+    bumpedVersion, check_node_sent_acknowledges_upgrade
 from indy_node.server.upgrade_log import UpgradeLog
-
 
 INVALID_VERSION = bumpedVersion()
 whitelist = ['unable to send message',
              'failed upgrade',
              'This problem may have external reasons, check syslog for more information']
+
 
 # TODO: Implement a client in node
 
@@ -23,10 +23,23 @@ def tdirWithPoolTxns(tdirWithPoolTxns, poolTxnNodeNames, tconf):
     return tdirWithPoolTxns
 
 
-def test_node_handles_unsuccessful_upgrade(looper, nodeSet, nodeIds):
-    check_node_set_acknowledges_upgrade(looper, nodeSet, nodeIds, [
-                                        IN_PROGRESS, FAIL], INVALID_VERSION)
-
+def test_node_detected_upgrade_failed(nodeSet):
+    '''
+    Test that each node checks Upgrade Log on startup (after Upgrade restart), and writes FAIL to it
+    because the current version differs from the one in Upgrade log.
+    Upgrade log already created START event (see fixture above emulating real upgrade)
+    '''
     for node in nodeSet:
         assert node.upgrader.scheduledUpgrade is None
         assert node.upgrader.lastUpgradeEventInfo[0] == UpgradeLog.UPGRADE_FAILED
+
+
+def test_node_sent_upgrade_fail(looper, nodeSet, nodeIds):
+    '''
+    Test that each node sends NODE_UPGRADE Fail event (because it sees FAIL in Upgrade log)
+    Upgrade log already created START event (see fixture above emulating real upgrade)
+    '''
+    check_node_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
+                                         allowed_actions=[FAIL],
+                                         ledger_size=len(nodeSet),
+                                         expected_version=INVALID_VERSION)


### PR DESCRIPTION
- If we send POOL_UPGRADE with force=true, then there is a chance that NODE_UPGRADE with IN_PROGRESS action will not be written to the ledger since all nodes in the pool are restarted at the same time, and the txn is getting lost and we have no consensus.
- After Node is restarted, it checked whether we had 1) START action in Upgrade log and 2)  NODE_UPGRADE with IN_PROGRESS action. If so, it sent Upgrade SUCCEESS or FAIL (depending on whether the current version equals to the expected one).
- In the situation with forced POOL_UPGRADE we didn't have IN_PROGRESS txn, so SUCCESS/FAIL NODE_UPGRADE txns may be not sent and written to the ledger
- It look like it's sufficient to check START action in Upgrade log only. If we have it, we send NODE_UPGRADE.  