### PR TITLE
INDY-953: Fix protocol version upgrade

### DIFF
--- a/indy_node/server/node.py
+++ b/indy_node/server/node.py
@@ -238,8 +238,8 @@ class Node(PlenumNode, HasPoolManager):
             return
         lastUpgradeVersion = self.upgrader.lastUpgradeEventInfo[2]
         action = COMPLETE if self.upgrader.didLastExecutedUpgradeSucceeded else FAIL
-        logger.info('{} found the first run after upgrade, '
-                     'sending NODE_UPGRADE {} to version {}'.format(self, action, lastUpgradeVersion))
+        logger.info('{} found the first run after upgrade, sending NODE_UPGRADE {} to version {}'.format(
+            self, action, lastUpgradeVersion))
         op = {
             TXN_TYPE: NODE_UPGRADE,
             DATA: {

--- a/indy_node/server/upgrade_log.py
+++ b/indy_node/server/upgrade_log.py
@@ -1,7 +1,8 @@
 import csv
 from datetime import datetime
-from dateutil.parser import parse as parse_date
 from os import path
+
+from dateutil.parser import parse as parse_date
 
 
 class UpgradeLog:
@@ -73,3 +74,6 @@ class UpgradeLog:
     def __iter__(self):
         for item in self.__items:
             yield item
+
+    def __len__(self):
+        return len(self.__items)

--- a/indy_node/server/upgrader.py
+++ b/indy_node/server/upgrader.py
@@ -339,7 +339,6 @@ class Upgrader(HasActionQueue):
                     self.nodeName, version))
                 return
 
-
             logger.info("Node '{}' schedules upgrade to {}".format(
                 self.nodeName, version))
 

--- a/indy_node/server/upgrader.py
+++ b/indy_node/server/upgrader.py
@@ -332,6 +332,8 @@ class Upgrader(HasActionQueue):
                     currentVersion, version, reinstall):
                 return
 
+            if isinstance(when, str):
+                when = dateutil.parser.parse(when)
             if self.scheduledUpgrade and self.scheduledUpgrade == (version, when, upgrade_id):
                 logger.debug("Node {} already scheduled upgrade to version '{}' ".format(
                     self.nodeName, version))

--- a/indy_node/server/upgrader.py
+++ b/indy_node/server/upgrader.py
@@ -162,6 +162,9 @@ class Upgrader(HasActionQueue):
         # send NODE_UPGRADE txn only if we were in Upgrade Started state at the very beginning (after Node restarted)
         return self._upgrade_started
 
+    def notified_about_upgrade_result(self):
+        self._upgrade_started = False
+
     def get_last_node_upgrade_txn(self, start_no: int = None):
         return self.get_upgrade_txn(
             lambda txn: txn[TXN_TYPE] == NODE_UPGRADE and txn[IDENTIFIER] == self.nodeId,
@@ -325,19 +328,27 @@ class Upgrader(HasActionQueue):
             when = txn[SCHEDULE][self.nodeId]
             failTimeout = txn.get(TIMEOUT, self.defaultUpgradeTimeout)
 
-            if self.is_version_upgradable(
+            if not self.is_version_upgradable(
                     currentVersion, version, reinstall):
-                logger.info("Node '{}' schedules upgrade to {}".format(
+                return
+
+            if self.scheduledUpgrade and self.scheduledUpgrade == (version, when, upgrade_id):
+                logger.debug("Node {} already scheduled upgrade to version '{}' ".format(
                     self.nodeName, version))
+                return
 
-                if self.scheduledUpgrade:
-                    logger.info(
-                        "Node '{}' cancels previous upgrade and schedules a new one to {}".format(
-                            self.nodeName, version))
-                    self._cancelScheduledUpgrade(justification)
 
-                self._scheduleUpgrade(
-                    version, when, failTimeout, upgrade_id)
+            logger.info("Node '{}' schedules upgrade to {}".format(
+                self.nodeName, version))
+
+            if self.scheduledUpgrade:
+                logger.info(
+                    "Node '{}' cancels previous upgrade and schedules a new one to {}".format(
+                        self.nodeName, version))
+                self._cancelScheduledUpgrade(justification)
+
+            self._scheduleUpgrade(
+                version, when, failTimeout, upgrade_id)
             return
 
         if action == CANCEL:

--- a/indy_node/test/upgrade/helper.py
+++ b/indy_node/test/upgrade/helper.py
@@ -180,6 +180,12 @@ def emulate_restart_pool_for_upgrade(nodes):
         node.acknowledge_upgrade()
 
 
+def emulate_view_change_pool_for_upgrade(nodes):
+    for node in nodes:
+        node.upgrader.processLedger()
+        node.acknowledge_upgrade()
+
+
 def check_node_do_not_sent_acknowledges_upgrade(
         looper, node_set, node_ids, allowed_actions: List, ledger_size, expected_version):
     '''

--- a/indy_node/test/upgrade/test_node_upgrade.py
+++ b/indy_node/test/upgrade/test_node_upgrade.py
@@ -2,12 +2,10 @@ import pytest
 
 import indy_node
 from indy_node.server.upgrade_log import UpgradeLog
-from stp_core.loop.eventually import eventually
-from indy_common.constants import IN_PROGRESS, COMPLETE
+from indy_common.constants import COMPLETE
 from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, \
-    check_node_sent_acknowledges_upgrade, check_ledger_after_upgrade, check_node_do_not_sent_acknowledges_upgrade, \
-    emulate_restart_pool_for_upgrade
-from plenum.test import waits as plenumWaits
+    check_node_sent_acknowledges_upgrade, check_node_do_not_sent_acknowledges_upgrade, \
+    emulate_restart_pool_for_upgrade, emulate_view_change_pool_for_upgrade
 
 whitelist = ['unable to send message']
 # TODO: Implement a client in node
@@ -49,13 +47,30 @@ def test_node_sent_upgrade_successful(looper, nodeSet, nodeIds):
                                          expected_version=version)
 
 
-def test_node_sent_upgrade_successful_once(looper, nodeSet, nodeIds):
+def test_node_sent_upgrade_successful_once_restart(looper, nodeSet, nodeIds):
     '''
-    Test that each node sends NODE_UPGRADE Success event only once,
+    Test that each node sends NODE_UPGRADE Success event only once after restart,
     so that if we restart the node it's not sent again
     '''
     # emulate restart
     emulate_restart_pool_for_upgrade(nodeSet)
+
+    # check that config ledger didn't changed (no new txns were sent)
+    check_node_do_not_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
+                                                allowed_actions=[COMPLETE],
+                                                ledger_size=len(nodeSet),
+                                                expected_version=version)
+
+
+def test_node_sent_upgrade_successful_once_view_change(looper, nodeSet, nodeIds):
+    '''
+    Test that each node sends NODE_UPGRADE Success event only once after each view change
+    '''
+    # emulate view changes 1-4
+    emulate_view_change_pool_for_upgrade(nodeSet)
+    emulate_view_change_pool_for_upgrade(nodeSet)
+    emulate_view_change_pool_for_upgrade(nodeSet)
+    emulate_view_change_pool_for_upgrade(nodeSet)
 
     # check that config ledger didn't changed (no new txns were sent)
     check_node_do_not_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,

--- a/indy_node/test/upgrade/test_node_upgrade.py
+++ b/indy_node/test/upgrade/test_node_upgrade.py
@@ -47,21 +47,6 @@ def test_node_sent_upgrade_successful(looper, nodeSet, nodeIds):
                                          expected_version=version)
 
 
-def test_node_sent_upgrade_successful_once_restart(looper, nodeSet, nodeIds):
-    '''
-    Test that each node sends NODE_UPGRADE Success event only once after restart,
-    so that if we restart the node it's not sent again
-    '''
-    # emulate restart
-    emulate_restart_pool_for_upgrade(nodeSet)
-
-    # check that config ledger didn't changed (no new txns were sent)
-    check_node_do_not_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
-                                                allowed_actions=[COMPLETE],
-                                                ledger_size=len(nodeSet),
-                                                expected_version=version)
-
-
 def test_node_sent_upgrade_successful_once_view_change(looper, nodeSet, nodeIds):
     '''
     Test that each node sends NODE_UPGRADE Success event only once after each view change
@@ -71,6 +56,21 @@ def test_node_sent_upgrade_successful_once_view_change(looper, nodeSet, nodeIds)
     emulate_view_change_pool_for_upgrade(nodeSet)
     emulate_view_change_pool_for_upgrade(nodeSet)
     emulate_view_change_pool_for_upgrade(nodeSet)
+
+    # check that config ledger didn't changed (no new txns were sent)
+    check_node_do_not_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
+                                                allowed_actions=[COMPLETE],
+                                                ledger_size=len(nodeSet),
+                                                expected_version=version)
+
+
+def test_node_sent_upgrade_successful_once_restart(looper, nodeSet, nodeIds):
+    '''
+    Test that each node sends NODE_UPGRADE Success event only once after restart,
+    so that if we restart the node it's not sent again
+    '''
+    # emulate restart
+    emulate_restart_pool_for_upgrade(nodeSet)
 
     # check that config ledger didn't changed (no new txns were sent)
     check_node_do_not_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,

--- a/indy_node/test/upgrade/test_node_upgrade_in_progress.py
+++ b/indy_node/test/upgrade/test_node_upgrade_in_progress.py
@@ -1,0 +1,22 @@
+from indy_common.constants import IN_PROGRESS
+from indy_node.test.upgrade.helper import check_node_sent_acknowledges_upgrade
+
+whitelist = ['unable to send message']
+
+
+def test_node_sent_upgrade_in_progress(looper, nodeSet, nodeIds, validUpgrade):
+    '''
+    Test that each node sends NODE_UPGRADE In Progress event
+    (because it sees scheduledUpgrade in the Upgrader)
+    '''
+    version = validUpgrade['version']
+    for node in nodeSet:
+        node_id = node.poolManager.get_nym_by_name(node.name)
+        node.upgrader.scheduledUpgrade = (version,
+                                 validUpgrade['schedule'][node_id],
+                                 "upgrade_id")
+        node.notify_upgrade_start()
+    check_node_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
+                                         allowed_actions=[IN_PROGRESS],
+                                         ledger_size=len(nodeSet),
+                                         expected_version=version)

--- a/indy_node/test/upgrade/test_node_upgrade_in_progress_no_protocol_version.py
+++ b/indy_node/test/upgrade/test_node_upgrade_in_progress_no_protocol_version.py
@@ -1,0 +1,36 @@
+import pytest
+
+from indy_common.constants import IN_PROGRESS
+from indy_node.test.helper import TestNode
+from indy_node.test.upgrade.helper import check_node_sent_acknowledges_upgrade
+
+whitelist = ['unable to send message']
+
+
+class TestNodeNoProtocolVersion(TestNode):
+    def processNodeRequest(self, request, frm):
+        if request.protocolVersion is not None:
+            raise ValueError('Do not understand what protocolVersion is!!!')
+        super().processNodeRequest(request, frm)
+
+
+@pytest.fixture(scope="module")
+def testNodeClass(patchPluginManager):
+    return TestNodeNoProtocolVersion
+
+
+def test_node_sent_upgrade_in_progress_no_protocol_version(looper, nodeSet, nodeIds, validUpgrade):
+    '''
+    Test that each node sends NODE_UPGRADE In Progress event
+    (because it sees scheduledUpgrade in the Upgrader)
+    '''
+    version = validUpgrade['version']
+    for node, node_id in zip(nodeSet, nodeIds):
+        node.upgrader.scheduledUpgrade = (version,
+                                          validUpgrade['schedule'][node_id],
+                                          "upgrade_id")
+        node.notify_upgrade_start()
+    check_node_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
+                                         allowed_actions=[IN_PROGRESS],
+                                         ledger_size=len(nodeSet),
+                                         expected_version=version)

--- a/indy_node/test/upgrade/test_node_upgrade_no_protocol_version.py
+++ b/indy_node/test/upgrade/test_node_upgrade_no_protocol_version.py
@@ -1,0 +1,46 @@
+import pytest
+
+import indy_node
+from indy_common.constants import COMPLETE
+from indy_node.test.helper import TestNode
+from indy_node.test.upgrade.helper import populate_log_with_upgrade_events, \
+    check_node_sent_acknowledges_upgrade
+
+whitelist = ['unable to send message']
+
+version = indy_node.__metadata__.__version__
+
+
+class TestNodeNoProtocolVersion(TestNode):
+    def processNodeRequest(self, request, frm):
+        if request.protocolVersion is not None:
+            raise ValueError('Do not understand what protocolVersion is!!!')
+        super().processNodeRequest(request, frm)
+
+
+@pytest.fixture(scope="module")
+def tdirWithPoolTxns(tdirWithPoolTxns, poolTxnNodeNames, tconf):
+    # For each node, adding a file with he current version number which makes the node
+    # think that an upgrade has been performed
+    populate_log_with_upgrade_events(
+        tdirWithPoolTxns,
+        poolTxnNodeNames,
+        tconf,
+        version)
+    return tdirWithPoolTxns
+
+
+@pytest.fixture(scope="module")
+def testNodeClass(patchPluginManager):
+    return TestNodeNoProtocolVersion
+
+
+def test_node_sent_upgrade_successful_no_protocol_version(testNodeClass, looper, nodeSet, nodeIds):
+    '''
+    Test that each node sends NODE_UPGRADE Success event (because it sees SUCCESS in Upgrade log)
+    Upgrade log already created START event (see fixture above emulating real upgrade)
+    '''
+    check_node_sent_acknowledges_upgrade(looper, nodeSet, nodeIds,
+                                         allowed_actions=[COMPLETE],
+                                         ledger_size=len(nodeSet),
+                                         expected_version=version)

--- a/indy_node/test/upgrade/test_node_upgrade_rescheduled_view_change.py
+++ b/indy_node/test/upgrade/test_node_upgrade_rescheduled_view_change.py
@@ -1,0 +1,37 @@
+import dateutil
+
+from indy_node.server.upgrade_log import UpgradeLog
+from indy_node.test.upgrade.helper import emulate_view_change_pool_for_upgrade
+
+whitelist = ['unable to send message']
+
+
+# TODO: Implement a client in node
+
+
+def test_scheduled_once_after_view_change(nodeSet, validUpgrade):
+    '''
+    Test that each node schedules update only once after each view change
+    '''
+    # schedule upgrade for each node
+    version = validUpgrade['version']
+    for node in nodeSet:
+        node_id = node.poolManager.get_nym_by_name(node.name)
+        node.upgrader._scheduleUpgrade(version,
+                                       validUpgrade['schedule'][node_id],
+                                       30,
+                                       "upgrade_id")
+
+    # emulate view changes 1-4
+    emulate_view_change_pool_for_upgrade(nodeSet)
+    emulate_view_change_pool_for_upgrade(nodeSet)
+    emulate_view_change_pool_for_upgrade(nodeSet)
+    emulate_view_change_pool_for_upgrade(nodeSet)
+
+    # check that there are no cancel events in Upgrade log
+    for node in nodeSet:
+        node_id = node.poolManager.get_nym_by_name(node.name)
+        when = dateutil.parser.parse(validUpgrade['schedule'][node_id])
+        assert node.upgrader.scheduledUpgrade == (version, when, "upgrade_id")
+        assert len(node.upgrader._upgradeLog) == 1
+        assert node.upgrader.lastUpgradeEventInfo == (UpgradeLog.UPGRADE_SCHEDULED, when, version, "upgrade_id")

--- a/indy_node/test/upgrade/test_node_upgrade_rescheduled_view_change.py
+++ b/indy_node/test/upgrade/test_node_upgrade_rescheduled_view_change.py
@@ -9,19 +9,10 @@ whitelist = ['unable to send message']
 # TODO: Implement a client in node
 
 
-def test_scheduled_once_after_view_change(nodeSet, validUpgrade):
+def test_scheduled_once_after_view_change(nodeSet, validUpgrade, upgradeScheduled):
     '''
     Test that each node schedules update only once after each view change
     '''
-    # schedule upgrade for each node
-    version = validUpgrade['version']
-    for node in nodeSet:
-        node_id = node.poolManager.get_nym_by_name(node.name)
-        node.upgrader._scheduleUpgrade(version,
-                                       validUpgrade['schedule'][node_id],
-                                       30,
-                                       "upgrade_id")
-
     # emulate view changes 1-4
     emulate_view_change_pool_for_upgrade(nodeSet)
     emulate_view_change_pool_for_upgrade(nodeSet)
@@ -29,9 +20,11 @@ def test_scheduled_once_after_view_change(nodeSet, validUpgrade):
     emulate_view_change_pool_for_upgrade(nodeSet)
 
     # check that there are no cancel events in Upgrade log
+    version = validUpgrade['version']
+    upgrade_id = nodeSet[0].upgrader.scheduledUpgrade[2]
     for node in nodeSet:
         node_id = node.poolManager.get_nym_by_name(node.name)
         when = dateutil.parser.parse(validUpgrade['schedule'][node_id])
-        assert node.upgrader.scheduledUpgrade == (version, when, "upgrade_id")
+        assert node.upgrader.scheduledUpgrade == (version, when, upgrade_id)
         assert len(node.upgrader._upgradeLog) == 1
-        assert node.upgrader.lastUpgradeEventInfo == (UpgradeLog.UPGRADE_SCHEDULED, when, version, "upgrade_id")
+        assert node.upgrader.lastUpgradeEventInfo == (UpgradeLog.UPGRADE_SCHEDULED, when, version, upgrade_id)


### PR DESCRIPTION
 fix issues with upgrade:

- do not send protocol version with NODE_UPGRADE txns (since some nodes in the pool may not yet understand it)
- do not reschedule the same upgrade
- do not re-send NODE_UPGRADE after each view change