### PR TITLE
nofile limits for node service, reverted for node control

### DIFF
--- a/build-scripts/ubuntu-1604/postinst_node
+++ b/build-scripts/ubuntu-1604/postinst_node
@@ -84,6 +84,7 @@ RestartSec=10
 StartLimitBurst=10
 StartLimitInterval=200
 TimeoutSec=300
+LimitNOFILE=16384:65536
 
 [Install]
 WantedBy=multi-user.target
@@ -106,7 +107,6 @@ RestartSec=10
 StartLimitBurst=10
 StartLimitInterval=200
 TimeoutSec=300
-LimitNOFILE=16384:65536
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- reverts commit 68335ea934542847f0a5edd1e5d03d4b2ee09246 because nofile limits were incorrectly added to node control service
- adds nofile limits for node service instead
