### PR TITLE
INDY-582: support setting of empty (None) verkey on client and server sides

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -310,6 +310,7 @@ creation of new DIDs, setting and rotation of verification key, setting and chan
     Target verification key as base58-encoded string. If not set, then either the target identifier
     (`dest`) is 32-bit cryptonym CID (this is deprecated), or this is a user under guardianship
     (doesnt owns the identifier yet).
+    Verkey can be changed to None by owner, it means that this user goes back under guardianship.
 
 - `alias` (string; optional): 
 

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -128,6 +128,7 @@ creation of new DIDs, setting and rotation of verification key, setting and chan
     Target verification key as base58-encoded string. If not set, then either the target identifier
     (`dest`) is 32-bit cryptonym CID (this is deprecated), or this is a user under guardianship
     (doesnt owns the identifier yet).
+    Verkey can be changed to None by owner, it means that this user goes back under guardianship.
 
 - `alias` (string; optional): 
 

--- a/indy_client/cli/constants.py
+++ b/indy_client/cli/constants.py
@@ -21,7 +21,7 @@ CLIENT_GRAMS_USE_KEYPAIR_FORMATTED_REG_EX = getPipedRegEx(
 TXN_NYM = "(\s* (?P<{{cmdName}}>{{cmd}}\s+{nym}) " \
           "\s+ (?P<dest>dest=) \s* (?P<dest_id>[A-Za-z0-9+=/]*)" \
           "(\s+ (?P<role_key>role=) \s* (?P<role>{trustee}|{tgb}|{trustAnchor}|{steward}|))?" \
-          "(\s+ (?P<ver_key>verkey=) \s* (?P<new_ver_key>[~A-Za-z0-9+=/]+))?)".format(nym=IndyTransactions.NYM.name,
+          "(\s+ (?P<ver_key>verkey=) \s* (?P<new_ver_key>[~A-Za-z0-9+=/]*))?)".format(nym=IndyTransactions.NYM.name,
                                                                                       trustee=Roles.TRUSTEE.name,
                                                                                       tgb=Roles.TGB.name,
                                                                                       trustAnchor=Roles.TRUST_ANCHOR.name,

--- a/indy_client/test/cli/test_command_reg_ex.py
+++ b/indy_client/test/cli/test_command_reg_ex.py
@@ -54,11 +54,13 @@ def testSendNymVerkey(grammar):
         "send_nym": "send NYM", "dest_id": dest, "role": role
     })
 
-    # Verkey being empty string is not supported
-    with pytest.raises(AssertionError):
-        matchedVars = getMatchedVariables(
-            grammar,
-            "send NYM dest={} role={} verkey={}".format(dest, role, ''))
+    # Verkey being empty string is supported
+    matchedVars = getMatchedVariables(
+        grammar,
+        "send NYM dest={} role={} verkey={}".format(dest, role, ''))
+    assertCliTokens(matchedVars, {
+        "send_nym": "send NYM", "dest_id": dest, "role": role, "new_ver_key": ''
+    })
 
 
 def testGetNym(grammar):

--- a/indy_client/test/cli/test_nym_suspension.py
+++ b/indy_client/test/cli/test_nym_suspension.py
@@ -146,3 +146,20 @@ def testTrusteeSuspendingTGB(be, do, trusteeCli, tbgAdded, nymAddedOut):
     do('send NYM dest={remote} role=',
        within=5,
        expect=nymAddedOut, mapper=tbgAdded)
+
+
+def testTrustAnchorSuspendingHimselfByVerkeyFlush(be, do, trusteeCli, trustAnchorAdded,
+                                                  nymAddedOut, trustAnchorCli):
+    # The trust anchor has already lost its role due to previous tests,
+    # but it is ok for this test where the trust anchor flushes its verkey
+    # and then he is unable to send NYM due to empty verkey.
+    be(trustAnchorCli)
+    do('send NYM dest={remote} verkey=',
+       within=5,
+       expect=nymAddedOut, mapper=trustAnchorAdded)
+
+    s = DidSigner().identifier
+    errorMsg = "CouldNotAuthenticate('Can not find verkey for"
+    do('send NYM dest={remote}',
+       within=5,
+       expect=[errorMsg], mapper={'remote': s})

--- a/indy_client/test/cli/test_send_nym_validation.py
+++ b/indy_client/test/cli/test_send_nym_validation.py
@@ -516,7 +516,7 @@ def testSendNymHasInvalidSyntaxForUuidIdentifierAndEmptyVerkey(
 
     be(trusteeCli)
     do('send NYM dest={dest} role={role} verkey={verkey}',
-       mapper=parameters, expect=INVALID_SYNTAX, within=2)
+       mapper=parameters, expect=NYM_ADDED, within=2)
 
 
 @pytest.mark.skip(reason='SOV-1111')

--- a/indy_common/identity.py
+++ b/indy_common/identity.py
@@ -79,7 +79,7 @@ class Identity(GeneratesRequest):
             TARGET_NYM: self.identity.identifier
         }
         if self.identity.verkey is not None:
-            op[VERKEY] = self.identity.verkey
+            op[VERKEY] = None if self.identity.verkey == '' else self.identity.verkey
         if self._role:
             op[ROLE] = self.role
         return op

--- a/indy_node/test/suspension/test_suspension.py
+++ b/indy_node/test/suspension/test_suspension.py
@@ -54,6 +54,13 @@ def anotherTrustAnchor(nodeSet, tdirWithClientPoolTxns, looper, trustee, trustee
                                   role=TRUST_ANCHOR)
 
 
+@pytest.fixture(scope="module")
+def anotherTrustAnchor1(nodeSet, tdirWithClientPoolTxns, looper, trustee, trusteeWallet):
+    return getClientAddedWithRole(nodeSet, tdirWithClientPoolTxns, looper,
+                                  trustee, trusteeWallet, 'newTrustAnchor1',
+                                  role=TRUST_ANCHOR)
+
+
 def testTrusteeAddingAnotherTrustee(anotherTrustee):
     pass
 
@@ -124,6 +131,16 @@ def testTrusteeCannotChangeVerkey(trustee, trusteeWallet, looper, nodeSet,
                      nAckReasonContains='TRUSTEE cannot update verkey')
         # Identity owner can change verkey
         changeVerkey(looper, *identity, wallet.defaultId, signer.verkey)
+
+
+def testTrustAnchorSuspendingHimselfByVerkeyFlush(looper, trustee, trusteeWallet, anotherTrustAnchor1):
+    _, wallet = anotherTrustAnchor1
+    changeVerkey(looper, *anotherTrustAnchor1, wallet.defaultId, '')
+    signer = DidSigner()
+    changeVerkey(looper, *anotherTrustAnchor1, wallet.defaultId, signer.verkey,
+                 nAckReasonContains="CouldNotAuthenticate('Can not find verkey for")
+    # Now NYM creator should have permission to set verkey.
+    changeVerkey(looper, trustee, trusteeWallet, wallet.defaultId, signer.verkey)
 
 
 # Keep the test below at the end of the suite since it will make one of the

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum-dev==1.2.235',
+    install_requires=['indy-plenum-dev==1.2.238',
                       'indy-anoncreds-dev==1.0.32',
                       'python-dateutil',
                       'timeout-decorator'],


### PR DESCRIPTION
Now any NYM owner can flush its verkey. In this case permissions for verkey updating goes back to creator.