### PR TITLE
INDY-1111: prevent creating a schema or claimDef without role

### DIFF
--- a/indy_client/test/anon_creds/conftest.py
+++ b/indy_client/test/anon_creds/conftest.py
@@ -30,6 +30,11 @@ def public_repo_2(trustee, trusteeWallet):
 
 
 @pytest.fixture(scope="module")
+def public_repo_for_client(client1, added_client_without_role):
+    return IndyPublicRepo(client1, added_client_without_role)
+
+
+@pytest.fixture(scope="module")
 def issuer(public_repo):
     return Issuer(IssuerWalletInMemory('issuer1', public_repo),
                   AttributeRepoInMemory())

--- a/indy_client/test/anon_creds/test_claim_def.py
+++ b/indy_client/test/anon_creds/test_claim_def.py
@@ -8,6 +8,7 @@ from stp_core.common.log import getlogger
 
 logger = getlogger()
 
+
 def test_error_submit_claim_def_by_client(submitted_schema_ID,
                                           public_key,
                                           public_revocation_key,
@@ -99,4 +100,3 @@ def test_submit_claim_def_same_schema_and_signature_type(submitted_claim_def,
                                             pk=public_key,
                                             pkR=public_revocation_key,
                                             signatureType='CL'))
-

--- a/indy_client/test/anon_creds/test_claim_def.py
+++ b/indy_client/test/anon_creds/test_claim_def.py
@@ -8,22 +8,21 @@ from stp_core.common.log import getlogger
 
 logger = getlogger()
 
+def test_error_submit_claim_def_by_client(submitted_schema_ID,
+                                          public_key,
+                                          public_revocation_key,
+                                          looper,
+                                          public_repo_for_client):
+    with pytest.raises(OperationError) as ex_info:
+        looper.run(public_repo_for_client.submitPublicKeys(id=submitted_schema_ID,
+                                                  pk=public_key,
+                                                  pkR=public_revocation_key,
+                                                  signatureType='CL'))
+        assert "role cannot add claim def" in ex_info[0]
+
 
 def test_submit_claim_def(submitted_claim_def):
     assert submitted_claim_def
-
-
-def test_submit_claim_def_same_schema_and_signature_type(submitted_claim_def,
-                                                         looper, public_repo,
-                                                         submitted_schema_ID,
-                                                         public_key, public_revocation_key):
-    assert submitted_claim_def
-    with pytest.raises(OperationError) as ex_info:
-        looper.run(public_repo.submitPublicKeys(id=submitted_schema_ID,
-                                                pk=public_key,
-                                                pkR=public_revocation_key,
-                                                signatureType='CL'))
-        ex_info.match("can have one and only one CLAIM_DEF")
 
 
 def test_submit_claim_def_same_schema_different_signature_type(
@@ -89,3 +88,15 @@ def test_get_revocation_public_key_non_existent(submitted_schema_ID,
     with pytest.raises(ValueError):
         looper.run(public_repo.getPublicKeyRevocation(id=schemaId,
                                                       signatureType='CL'))
+
+
+def test_submit_claim_def_same_schema_and_signature_type(submitted_claim_def,
+                                                         looper, public_repo,
+                                                         submitted_schema_ID,
+                                                         public_key, public_revocation_key):
+    assert submitted_claim_def
+    looper.run(public_repo.submitPublicKeys(id=submitted_schema_ID,
+                                            pk=public_key,
+                                            pkR=public_revocation_key,
+                                            signatureType='CL'))
+

--- a/indy_client/test/anon_creds/test_claim_def.py
+++ b/indy_client/test/anon_creds/test_claim_def.py
@@ -9,16 +9,16 @@ from stp_core.common.log import getlogger
 logger = getlogger()
 
 
-def test_error_submit_claim_def_by_client(submitted_schema_ID,
-                                          public_key,
-                                          public_revocation_key,
-                                          looper,
-                                          public_repo_for_client):
+def test_can_not_submit_claim_def_by_identity_owner(submitted_schema_ID,
+                                                    public_key,
+                                                    public_revocation_key,
+                                                    looper,
+                                                    public_repo_for_client):
     with pytest.raises(OperationError) as ex_info:
         looper.run(public_repo_for_client.submitPublicKeys(id=submitted_schema_ID,
-                                                  pk=public_key,
-                                                  pkR=public_revocation_key,
-                                                  signatureType='CL'))
+                                                           pk=public_key,
+                                                           pkR=public_revocation_key,
+                                                           signatureType='CL'))
         assert "role cannot add claim def" in ex_info[0]
 
 

--- a/indy_client/test/anon_creds/test_schema.py
+++ b/indy_client/test/anon_creds/test_schema.py
@@ -33,8 +33,9 @@ def test_submit_same_schema_twice(looper, public_repo,
         ex_info.match("can have one and only one SCHEMA with name GVT and version 1.0'")
 
 
-def test_submit_schema_without_role(looper, public_repo_for_client,
-                                    schema):
+def test_can_not_submit_schema_by_identity_owner(looper,
+                                                 public_repo_for_client,
+                                                 schema):
     with pytest.raises(OperationError) as ex_info:
         looper.run(
             public_repo_for_client.submitSchema(schema)

--- a/indy_client/test/anon_creds/test_schema.py
+++ b/indy_client/test/anon_creds/test_schema.py
@@ -33,6 +33,15 @@ def test_submit_same_schema_twice(looper, public_repo,
         ex_info.match("can have one and only one SCHEMA with name GVT and version 1.0'")
 
 
+def test_submit_schema_without_role(looper, public_repo_for_client,
+                                    schema):
+    with pytest.raises(OperationError) as ex_info:
+        looper.run(
+            public_repo_for_client.submitSchema(schema)
+        )
+        ex_info.match("role cannot add claim def")
+
+
 def test_get_schema(submitted_schema, public_repo, looper):
     key = submitted_schema.getKey()
     schema = looper.run(public_repo.getSchema(ID(schemaKey=key)))

--- a/indy_client/test/cli/test_send_claim_def.py
+++ b/indy_client/test/cli/test_send_claim_def.py
@@ -59,8 +59,8 @@ def test_send_claim_def_fails_if_ref_is_not_existing_seqno(
        within=5)
 
 
-def test_can_not_send_claim_def_for_same_schema_and_signature_type(
-        be, do, poolNodesStarted, trusteeCli):
+def test_update_claim_def_for_same_schema_and_signature_type(
+        be, do, trusteeCli):
     be(trusteeCli)
 
     do('send SCHEMA name=Degree version=1.3'
@@ -76,9 +76,10 @@ def test_can_not_send_claim_def_for_same_schema_and_signature_type(
        within=239)
 
     do('send CLAIM_DEF ref={ref} signature_type=CL',
-       expect='can have one and only one CLAIM_DEF',
+       expect=CLAIM_DEF_ADDED,
        mapper={'ref': schemaTxnSeqNo},
-       within=5)
+       within=239)
+
 
 def test_can_send_same_claim_def_by_different_issuers(
         be, do, poolNodesStarted, trusteeCli, newStewardCli):

--- a/indy_client/test/conftest.py
+++ b/indy_client/test/conftest.py
@@ -208,6 +208,18 @@ def client1(clientAndWallet1, looper):
 
 
 @pytest.fixture(scope="module")
+def added_client_without_role(steward, stewardWallet, looper,
+                           wallet1):
+    createNym(looper,
+              wallet1.defaultId,
+              steward,
+              stewardWallet,
+              role=None,
+              verkey=wallet1.getVerkey())
+    return wallet1
+
+
+@pytest.fixture(scope="module")
 def wallet1(clientAndWallet1):
     return clientAndWallet1[1]
 

--- a/indy_common/auth.py
+++ b/indy_common/auth.py
@@ -1,7 +1,7 @@
 from plenum.common.constants import TRUSTEE, STEWARD, NODE
 from stp_core.common.log import getlogger
 
-from indy_common.constants import OWNER, POOL_UPGRADE, TGB, TRUST_ANCHOR, NYM, POOL_CONFIG
+from indy_common.constants import OWNER, POOL_UPGRADE, TGB, TRUST_ANCHOR, NYM, POOL_CONFIG, SCHEMA, CLAIM_DEF
 from indy_common.roles import Roles
 
 logger = getlogger()
@@ -32,6 +32,10 @@ class Authoriser:
             {TRUSTEE: []},
         '{}_role_{}_'.format(NYM, TRUST_ANCHOR):
             {TRUSTEE: []},
+        '{}_role_<any>_<any>'.format(SCHEMA):
+            {TRUSTEE: [OWNER, ], STEWARD: [OWNER, ], TRUST_ANCHOR: [OWNER, ]},
+        '{}_role_<any>_<any>'.format(CLAIM_DEF):
+            {TRUSTEE: [OWNER, ], STEWARD: [OWNER, ], TRUST_ANCHOR: [OWNER, ]},
         '{}_verkey_<any>_<any>'.format(NYM):
             {r: [OWNER] for r in ValidRoles},
         '{}_services__[VALIDATOR]'.format(NODE):

--- a/indy_common/test/auth/test_auth_claim_def.py
+++ b/indy_common/test/auth/test_auth_claim_def.py
@@ -1,0 +1,34 @@
+from plenum.common.constants import TRUSTEE, STEWARD
+
+from indy_common.auth import Authoriser
+from indy_common.constants import ROLE, TGB, TRUST_ANCHOR, CLAIM_DEF
+
+
+def test_claim_def_adding():
+    roles = {TRUSTEE, STEWARD, TRUST_ANCHOR}
+    for role in roles:
+        r, msg = _authorised_for_claim_def(role, True)
+        assert r and not msg
+
+
+def test_claim_def_adding_without_permission():
+    roles = {TGB, None}
+    for role in roles:
+        r, msg = _authorised_for_claim_def(role, True)
+        assert not r and msg
+
+
+def test_claim_def_adding_not_owner():
+    roles = {TRUSTEE, STEWARD, TRUST_ANCHOR}
+    for role in roles:
+        r, msg = _authorised_for_claim_def(role, False)
+        assert not r and msg == "Only owner is allowed"
+
+
+def _authorised_for_claim_def(role, is_owner):
+    return Authoriser.authorised(typ=CLAIM_DEF,
+                                 field=ROLE,
+                                 actorRole=role,
+                                 oldVal=None,
+                                 newVal=None,
+                                 isActorOwnerOfSubject=is_owner)

--- a/indy_common/test/auth/test_auth_schema.py
+++ b/indy_common/test/auth/test_auth_schema.py
@@ -1,0 +1,34 @@
+from plenum.common.constants import TRUSTEE, STEWARD
+
+from indy_common.auth import Authoriser
+from indy_common.constants import ROLE, TGB, TRUST_ANCHOR, SCHEMA
+
+
+def test_schema_adding():
+    roles = {TRUSTEE, STEWARD, TRUST_ANCHOR}
+    for role in roles:
+        r, msg = _authorised_for_schemas(role, True)
+        assert r and not msg
+
+
+def test_schema_adding_without_permission():
+    roles = {TGB, None}
+    for role in roles:
+        r, msg = _authorised_for_schemas(role, True)
+        assert not r and msg
+
+
+def test_schema_adding_not_owner():
+    roles = {TRUSTEE, STEWARD, TRUST_ANCHOR}
+    for role in roles:
+        r, msg = _authorised_for_schemas(role, False)
+        assert not r and msg == "Only owner is allowed"
+
+
+def _authorised_for_schemas(role, is_owner):
+    return Authoriser.authorised(typ=SCHEMA,
+                                 field=ROLE,
+                                 actorRole=role,
+                                 oldVal=None,
+                                 newVal=None,
+                                 isActorOwnerOfSubject=is_owner)

--- a/indy_node/server/domain_req_handler.py
+++ b/indy_node/server/domain_req_handler.py
@@ -278,23 +278,14 @@ class DomainReqHandler(PHandler):
             raise UnknownIdentifier(
                 req.identifier,
                 req.reqId)
-        if claim_def:
-            origin = req.identifier
-            owner = self.idrCache.getOwnerFor(req.identifier, isCommitted=False)
-            is_owner = origin == owner
-            r, msg = Authoriser.authorised(typ=CLAIM_DEF,
-                                           field=ROLE,
-                                           actorRole=origin_role,
-                                           oldVal=None,
-                                           newVal=None,
-                                           isActorOwnerOfSubject=is_owner)
-        else:
-            r, msg = Authoriser.authorised(typ=CLAIM_DEF,
-                                           field=ROLE,
-                                           actorRole=origin_role,
-                                           oldVal=None,
-                                           newVal=None,
-                                           isActorOwnerOfSubject=True)
+        # only owner can update claim_def,
+        # because his identifier is the primary key of claim_def
+        r, msg = Authoriser.authorised(typ=CLAIM_DEF,
+                                       field=ROLE,
+                                       actorRole=origin_role,
+                                       oldVal=None,
+                                       newVal=None,
+                                       isActorOwnerOfSubject=True)
         if not r:
             raise UnauthorizedClientRequest(
                 req.identifier,

--- a/indy_node/server/domain_req_handler.py
+++ b/indy_node/server/domain_req_handler.py
@@ -237,6 +237,26 @@ class DomainReqHandler(PHandler):
                                        '{} can have one and only one SCHEMA with '
                                        'name {} and version {}'
                                        .format(identifier, schema_name, schema_version))
+        try:
+            origin_role = self.idrCache.getRole(
+                req.identifier, isCommitted=False) or None
+        except BaseException:
+            raise UnknownIdentifier(
+                req.identifier,
+                req.reqId)
+        r, msg = Authoriser.authorised(typ=SCHEMA,
+                                       field=ROLE,
+                                       actorRole=origin_role,
+                                       oldVal=None,
+                                       newVal=None,
+                                       isActorOwnerOfSubject=True)
+        if not r:
+            raise UnauthorizedClientRequest(
+                req.identifier,
+                req.reqId,
+                "{} cannot add schema".format(
+                    Roles.nameFromValue(origin_role))
+            )
 
     def _validate_claim_def(self, req: Request):
         # we can not add a Claim Def with existent ISSUER_DID
@@ -250,11 +270,38 @@ class DomainReqHandler(PHandler):
             schemaSeqNo=schema_ref,
             signatureType=signature_type
         )
+
+        try:
+            origin_role = self.idrCache.getRole(
+                req.identifier, isCommitted=False) or None
+        except BaseException:
+            raise UnknownIdentifier(
+                req.identifier,
+                req.reqId)
         if claim_def:
-            raise InvalidClientRequest(identifier, req.reqId,
-                                       '{} can have one and only one CLAIM_DEF for '
-                                       'and schema ref {} and signature type {}'
-                                       .format(identifier, schema_ref, signature_type))
+            origin = req.identifier
+            owner = self.idrCache.getOwnerFor(req.identifier, isCommitted=False)
+            is_owner = origin == owner
+            r, msg = Authoriser.authorised(typ=CLAIM_DEF,
+                                           field=ROLE,
+                                           actorRole=origin_role,
+                                           oldVal=None,
+                                           newVal=None,
+                                           isActorOwnerOfSubject=is_owner)
+        else:
+            r, msg = Authoriser.authorised(typ=CLAIM_DEF,
+                                           field=ROLE,
+                                           actorRole=origin_role,
+                                           oldVal=None,
+                                           newVal=None,
+                                           isActorOwnerOfSubject=True)
+        if not r:
+            raise UnauthorizedClientRequest(
+                req.identifier,
+                req.reqId,
+                "{} cannot add claim def".format(
+                    Roles.nameFromValue(origin_role))
+            )
 
     def _validate_revoc_reg_def(self, req: Request):
         operation = req.operation

--- a/indy_node/server/domain_req_handler.py
+++ b/indy_node/server/domain_req_handler.py
@@ -261,16 +261,6 @@ class DomainReqHandler(PHandler):
     def _validate_claim_def(self, req: Request):
         # we can not add a Claim Def with existent ISSUER_DID
         # sine a Claim Def needs to be identified by seqNo
-        identifier = req.identifier
-        operation = req.operation
-        schema_ref = operation[REF]
-        signature_type = operation[SIGNATURE_TYPE]
-        claim_def, _, _, _ = self.getClaimDef(
-            author=identifier,
-            schemaSeqNo=schema_ref,
-            signatureType=signature_type
-        )
-
         try:
             origin_role = self.idrCache.getRole(
                 req.identifier, isCommitted=False) or None


### PR DESCRIPTION
- added validation for schema and claimDef adding
- expanded the permission map in auth.py
- added unit tests for auth.py
- added integration tests for domain_req_handler.py

Signed-off-by: toktar <renata.toktar@dsr-corporation.com>