### PR TITLE
INDY-1227: change documentation for indy-running-locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,14 @@ The described process is automated in one of the ways below (it allow to install
 
  - **Docker** [Start Pool and Client with Docker](environment/docker/pool/README.md)
  
- - **Running locally** [Running pool locally](docs/indy-running-locally.md) or [Indy Cluster Simulation](docs/cluster-simulation.md)
+ - **Running locally** [Indy Cluster Simulation](docs/cluster-simulation.md)
+
+ - **Docker-based pool using with new libindy-based CLI**:
+   - [Start Pool Locally](https://github.com/hyperledger/indy-sdk/blob/master/README.md#how-to-start-local-nodes-pool-with-docker)
+   - [Get Started with Libindy](https://github.com/hyperledger/indy-sdk/blob/master/doc/getting-started/getting-started.md)
 
  - **Also coming soon:** Create virtual machines in AWS.
+
 
 
 ## How to Start Working with the Code

--- a/docs/indy-running-locally.md
+++ b/docs/indy-running-locally.md
@@ -7,6 +7,12 @@ However, being test nodes, sometimes they aren’t, or sometimes you just want t
 
 This guide describes the process of setting up a local 4 node cluster and attaching the 3 Agents required [use the Indy CLI](https://github.com/hyperledger/indy-node/blob/master/getting-started.md#using-the-indy-cli) and impersonate Alice.
 
+**WARNING:** This script is not intended way to start the pool. You can install a test network in one of several ways:
+
+ - **Automated VM Creation with Vagrant** [Create virtual machines](environment/vagrant/training/vb-multi-vm/TestIndyClusterSetup.md) using VirtualBox and Vagrant.
+ - **Docker:** [Start Pool and Client with Docker](environment/docker/pool/StartIndyAgents.md).
+
+
 
 ## Requirements
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -61,7 +61,7 @@ You can install a test network in one of several ways:
 
  - **Automated VM Creation with Vagrant** [Create virtual machines](environment/vagrant/training/vb-multi-vm/TestIndyClusterSetup.md) using VirtualBox and Vagrant.
 
- - **Running locally** [Running pool locally](docs/indy-running-locally.md) or [Indy Cluster Simulation](docs/cluster-simulation.md)
+ - **Running locally** [Indy Cluster Simulation](docs/cluster-simulation.md)
 
  - **Docker:** [Start Pool and Client with Docker](environment/docker/pool/StartIndyAgents.md).
 


### PR DESCRIPTION
Changes:
- Removed all references to indy-running-locally from main documentation (README)
- Haved a bold warning in this script that it should not be used and Docker/Vagrant are appropriate options.
- Mentioned Docker-based solution from libindy repo to start the pool locally in README.

Signed-off-by: toktar <renata.toktar@dsr-corporation.com>