### PR TITLE
fixes ExecStart systemd's option for node control tool

### DIFF
--- a/build-scripts/ubuntu-1604/postinst_node
+++ b/build-scripts/ubuntu-1604/postinst_node
@@ -114,7 +114,7 @@ After=network.target
 [Service]
 Type=simple
 EnvironmentFile=$GENERAL_CONFIG_DIR/node_control.conf
-ExecStart=/usr/bin/env python3 -O /usr/local/bin/start_node_control_tool \${TEST_MODE} --hold-ext "\${HOLD_EXT}"
+ExecStart=/usr/bin/env python3 -O /usr/local/bin/start_node_control_tool \$TEST_MODE --hold-ext "\${HOLD_EXT}"
 Restart=on-failure
 RestartSec=10
 StartLimitBurst=10

--- a/build-scripts/ubuntu-1604/postinst_node
+++ b/build-scripts/ubuntu-1604/postinst_node
@@ -114,7 +114,7 @@ After=network.target
 [Service]
 Type=simple
 EnvironmentFile=$GENERAL_CONFIG_DIR/node_control.conf
-ExecStart=/usr/bin/env python3 -O /usr/local/bin/start_node_control_tool \$TEST_MODE --hold-ext "\${HOLD_EXT}"
+ExecStart=/usr/bin/env python3 -O /usr/local/bin/start_node_control_tool \$TEST_MODE --hold-ext \${HOLD_EXT}
 Restart=on-failure
 RestartSec=10
 StartLimitBurst=10


### PR DESCRIPTION
see "Basic environment variable substitution is supported" part in
https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines

Signed-off-by: Andrey Kononykhin <andkononykhin@gmail.com>