### PR TITLE
INDY-1227: remove link to Indy Cluster Simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ The described process is automated in one of the ways below (it allow to install
  - **Automated VM Creation with Vagrant** [Create virtual machines](environment/vagrant/training/vb-multi-vm/TestIndyClusterSetup.md) using VirtualBox and Vagrant.
 
  - **Docker** [Start Pool and Client with Docker](environment/docker/pool/README.md)
- 
- - **Running locally** [Indy Cluster Simulation](docs/cluster-simulation.md)
 
  - **Docker-based pool using with new libindy-based CLI**:
    - [Start Pool Locally](https://github.com/hyperledger/indy-sdk/blob/master/README.md#how-to-start-local-nodes-pool-with-docker)

--- a/getting-started.md
+++ b/getting-started.md
@@ -62,8 +62,6 @@ You can install a test network in one of several ways:
 
  - **Automated VM Creation with Vagrant** [Create virtual machines](environment/vagrant/training/vb-multi-vm/TestIndyClusterSetup.md) using VirtualBox and Vagrant.
 
- - **Running locally** [Indy Cluster Simulation](docs/cluster-simulation.md)
-
  - **Docker:** [Start Pool and Client with Docker](environment/docker/pool/StartIndyAgents.md).
 
  - **Also coming soon:** Create virtual machines in AWS.


### PR DESCRIPTION
Changes:
- remove link to Indy Cluster Simulation from readme
- remove link to Indy Cluster Simulation from GSG

Signed-off-by: toktar <renata.toktar@dsr-corporation.com>