### PR TITLE
Fixed typo for DID: from 'Distributed Identifier' to 'Decentralized Identifier'

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -173,7 +173,7 @@ This is a friendly name for the connection that Alice has been invited to accept
 DID: not yet assigned
 ```
 
-**DID** (**distributed identifier**) is an opaque, unique sequences of bits, (like UUIDs or GUIDs) that get generated when a user tries to accept the connection request. That DID will be sent to Faber College, and used by Faber College to reference Alice in secure interactions.
+**DID** (**Decentralized Identifier**) is an opaque, unique sequences of bits, (like UUIDs or GUIDs) that get generated when a user tries to accept the connection request. That DID will be sent to Faber College, and used by Faber College to reference Alice in secure interactions.
  Each connection request on the Indy network establishes a **pairwise relationship** when accepted. A pairwise relationship is a unique relationship between two identity owners (e.g., Faber and Alice). The relationship between them is not shareable with others; it is unique to those two parties in that each pairwise relationship uses different DIDs. (In other circles you may see this defined as two sets of data working in conjunction with each other to perform a specific function, such as in a "public" key and a "private" key working together. This is _not_ how it is defined within the Indy code base.) Alice won’t use this DID with other relationships. By having independent pairwise relationships, Alice reduces the ability for others to correlate her activities across multiple interactions.
 
 ```


### PR DESCRIPTION
In the latest [Getting Started with Indy][target-master] document ([here][target-pinned] for the version-pinned link), it states that `DID` is the short form for `Distributed Identity`.

However, according to various sources below, I believe that the correct term should be `Decentralized Identity`:

- [W3C: Decentralized Identifiers (DIDs) v0.9][w3c]
- [Sovirn: Sovrin Glossary][glossary]
- [Sovirn: Sovrin Provisional Trust Framework][sptf]

[target-master]: https://github.com/hyperledger/indy-node/blob/master/getting-started.md#evaluate-a-connection-request
[target-pinned]: https://github.com/hyperledger/indy-node/blob/c5db000fe39ae4000b543d2d77e32be2ff0c156f/getting-started.md#evaluate-a-connection-request

[w3c]: https://w3c-ccg.github.io/did-spec/

[glossary]: https://sovrin.org/wp-content/uploads/2017/04/Sovrin-Glossary.pdf

[sptf]: https://sovrin.org/wp-content/uploads/2018/03/Sovrin-Provisional-Trust-Framework-2017-06-28.pdf

Signed-off-by: Kenji Siu <kenjisiu@hk1.ibm.com>