### PR TITLE
INDY-1289: support read-only state in read_ledger with RocksDB.

### DIFF
--- a/scripts/read_ledger
+++ b/scripts/read_ledger
@@ -8,9 +8,12 @@ import logging
 import os
 import shutil
 
+from pathlib import Path
+
 from common.serializers.json_serializer import JsonSerializer
 from ledger.compact_merkle_tree import CompactMerkleTree
 from plenum.common.ledger import Ledger
+from plenum.common.constants import HS_ROCKSDB
 from storage.helper import initHashStore
 
 from indy_common.config_util import getConfig
@@ -92,7 +95,7 @@ def get_ledger(type_, ledger_data_dir):
         print("Unknown ledger type: {}".format(type_))
         exit()
 
-    hash_store = initHashStore(ledger_data_dir, type_, config)
+    hash_store = initHashStore(ledger_data_dir, type_, config, read_only=True)
     return Ledger(CompactMerkleTree(hashStore=hash_store), dataDir=ledger_data_dir, fileName=ledger_name)
 
 
@@ -153,15 +156,26 @@ def make_copy_of_ledger(data_dir):
 
 if __name__ == '__main__':
     args = read_args()
+    config = getConfig()
 
-    # TODO: works well only for small ledgers,
     ledger_data_dir = get_ledger_dir(args.node_name, args.client_name, args.network)
     read_copy_ledger_data_dir = None
     try:
-        read_copy_ledger_data_dir = make_copy_of_ledger(ledger_data_dir)
-        ledger = get_ledger(args.type, read_copy_ledger_data_dir)
+        # RocksDB supports real read-only mode and does not need to have a ledger copy.
+        if config.hashStore['type'].lower() != HS_ROCKSDB:
+            # NOTE: such approach works well only for small ledgers.
+            tmp = make_copy_of_ledger(ledger_data_dir)
+
+            # Let's be paranoid to avoid removing of ledger instead of its copy.
+            ledger_path = Path(ledger_data_dir)
+            ledger_copy_path = Path(tmp)
+            assert ledger_path != ledger_copy_path
+            assert ledger_copy_path not in ledger_path.parents
+
+            read_copy_ledger_data_dir = tmp
+            ledger_data_dir = read_copy_ledger_data_dir
+        ledger = get_ledger(args.type, ledger_data_dir)
         print_txns(ledger, args)
     finally:
-        # TODO be careful about removing original the ledger data dir
         if read_copy_ledger_data_dir:
             shutil.rmtree(read_copy_ledger_data_dir)

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum-dev==1.2.342',
+    install_requires=['indy-plenum-dev==1.2.344',
                       'indy-anoncreds-dev==1.0.32',
                       'python-dateutil',
                       'timeout-decorator==0.4.0'],


### PR DESCRIPTION
Since read-only mode is supported for RocksDB a copy of
ledger is not created in case of RocksDB-based ledger.

Also added additional checks to avoid removing of the
ledger instead of it's copy.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>