### PR TITLE
INDY-1324 fix typo error "Continues" to "Continuous"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * [How to Install a Test Network](#how-to-install-a-test-network)
 * [How to Start Working with the Code](#how-to-start-working-with-the-code)
 * [How to Start Indy Client CLI](#how-to-start-indy-client-cli)
-* [Continues integration and delivery](#continues-integration-and-delivery)
+* [Continuous integration and delivery](#continues-integration-and-delivery)
 * [How to send a PR](#how-to-send-a-pr)
 * [Docs and links](#docs-and-links)
 
@@ -129,9 +129,9 @@ Note: For Windows, we recommended using either [cmder](http://cmder.net/) or [co
 indy
 ```
 
-## Continues Integration and Delivery
+## Continuous Integration and Delivery
 
-Please have a look at [Continues integration/delivery](docs/ci-cd.md)
+Please have a look at [Continuous integration/delivery](docs/ci-cd.md)
 
 ## How to send a PR
 
@@ -181,9 +181,3 @@ If you made changes in both indy-plenum and indy-node, you need to do the follow
 - [Indy file folder structure guideline](docs/indy-file-structure-guideline.md)
 - [Helper Scripts](docs/helper-scripts.md)
 - [Pool Upgrade](docs/pool-upgrade.md)
-
-
-
-
-
-

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,4 +1,4 @@
-# Continues Integration / Delivery
+# Continuous Integration / Delivery
 
 #### Branches
 
@@ -10,7 +10,7 @@
 - Each PR needs to be reviewed.
 - PR can be merged only after all tests pass and code is reviewed.
 
-## Continues Integration
+## Continuous Integration
 
 - for each PR we execute:
     - static code validation
@@ -29,7 +29,7 @@
     - Run validation on the root folder of the project: `flake8 .`
 
 
-## Continues Delivery
+## Continuous Delivery
 
 - CD part of the pipeline is defined in `Jenkinsfile.cd` file.
 - CD part is run on a private Jenkins server dealing with issuing and uploading new builds.


### PR DESCRIPTION
This patch fix the typo error observed in ci documentation

Signed-off-by: rameshthoomu <rameshbabu.thoomu@gmail.com>