### PR TITLE
[WIP][skip ci][INDY-1363] add unsigned and signed action to ActionReqHandler

### DIFF
--- a/indy_node/server/action_req_handler.py
+++ b/indy_node/server/action_req_handler.py
@@ -22,7 +22,8 @@ logger = getlogger()
 
 
 class ActionReqHandler(RequestHandler):
-    operation_types = {POOL_RESTART, VALIDATOR_INFO}
+    unsigned_action_types = {VALIDATOR_INFO, }
+    signed_action_types = {POOL_RESTART, }
 
     def __init__(self, idrCache: IdrCache,
                  restarter: Restarter, poolManager, poolCfg: PoolConfig,
@@ -85,3 +86,7 @@ class ActionReqHandler(RequestHandler):
         return {**request.operation, **{
             f.IDENTIFIER.nm: request.identifier,
             f.REQ_ID.nm: request.reqId}}
+
+    @property
+    def operation_types(self):
+        return self.signed_action_types.union(self.unsigned_action_types)


### PR DESCRIPTION
Previously, the sending of the validator info command could only be signed. Now this feature is eliminated.

Changes:
- added unsigned_action_types and signed_action_types to ActionReqHandler