### PR TITLE
added option --nagios to produce Nagios output

### DIFF
--- a/scripts/validator-info
+++ b/scripts/validator-info
@@ -580,7 +580,7 @@ def get_stats_from_file(fpath, verbose, _json, _nagios):
     if _json:
         return json.dumps(vstats, indent=2, cls=NewEncoder)
     if _nagios:
-       return nagios(vstats)
+        return nagios(vstats)
 
     return vstats
 

--- a/scripts/validator-info
+++ b/scripts/validator-info
@@ -536,14 +536,53 @@ def accept_client(client_reader, client_writer):
     task.add_done_callback(client_done)
 
 
-def get_stats_from_file(fpath, verbose, _json):
+def nagios(vstats):
+    state = '2'
+    running = "{}".format(vstats['state'])
+    if "running" == running:
+        state = '0'
+
+    lines = [
+        "{} {}_Total_Config_Transactions config_transactions={} {} Total Config Transactions".format(
+                state,vstats['Node_info']['Name'],vstats['Node_info']['Metrics']['transaction-count']['config'],vstats['Node_info']['Name'])
+    ] + [
+        "{} {}_Total_Ledger_Transactions ledger_transactions={} {} Total Ledger Transactions".format(
+            state,vstats['Node_info']['Name'],vstats['Node_info']['Metrics']['transaction-count']['ledger'],vstats['Node_info']['Name'])
+    ] + [
+        "{} {}_Total_Pool_Transactions pool_transactions={} {} Total Pool Transactions".format(
+            state,vstats['Node_info']['Name'],vstats['Node_info']['Metrics']['transaction-count']['pool'],vstats['Node_info']['Name'])
+    ] + [
+        "{} {}_Read_Transactions_per_second read_transactions_per_second={} {} Read Transactions/Second".format(
+            state,vstats['Node_info']['Name'],vstats['Node_info']['Metrics']['average-per-second']['read-transactions'],vstats['Node_info']['Name'])
+    ] + [
+        "{} {}_Write_Transactions_per_second write_transactions_per_second={} {} Write Transactions/Second".format(
+            state,vstats['Node_info']['Name'],vstats['Node_info']['Metrics']['average-per-second']['write-transactions'],vstats['Node_info']['Name'])
+    ] + [
+        "{} {}_Number_of_Validators number_of_validators={} {} Number of Validators".format(
+            state,vstats['Node_info']['Name'],vstats['Pool_info']['Total_nodes_count'],vstats['Node_info']['Name'])
+    ] + [
+        "{} {}_Reachable_Validators reachable_validators={} {} Reachable Validators".format(
+            state,vstats['Node_info']['Name'],vstats['Pool_info']['Reachable_nodes_count'],vstats['Node_info']['Name'])
+    ] + [
+        "{} {}_Unreachable_Validators unreachable_validators={} {} Unreachable Validators".format(
+            state,vstats['Node_info']['Name'],vstats['Pool_info']['Unreachable_nodes_count'],vstats['Node_info']['Name'])
+    ]
+    return "\n".join(lines);
+
+
+def get_stats_from_file(fpath, verbose, _json, _nagios):
     with open(fpath) as f:
         stats = json.loads(f.read())
 
     logger.debug("Data {}".format(stats))
     vstats = ValidatorStats(stats, verbose)
 
-    return (json.dumps(vstats, indent=2, cls=NewEncoder) if _json else vstats)
+    if _json:
+        return json.dumps(vstats, indent=2, cls=NewEncoder)
+    if _nagios:
+       return nagios(vstats)
+
+    return vstats
 
 
 def watch(fpath, verbose, _json):
@@ -654,6 +693,10 @@ def main():
         "--json", action="store_true",
         help="Format output as JSON (ignores -v)"
     )
+    parser.add_argument(
+        "--nagios", action="store_true",
+        help="Format output as NAGIOS output (ignores -v)"
+    )
 
     statfile_group = parser.add_argument_group(
         "statfile", "settings for exploring validator stats from stat file"
@@ -757,7 +800,7 @@ def main():
             with open(file_path) as f_stats:
                 print("{}".format(os.linesep).join(create_print_tree(json.load(f_stats), lines=[])))
         else:
-            print(get_stats_from_file(file_path, args.verbose, args.json))
+            print(get_stats_from_file(file_path, args.verbose, args.json, args.nagios))
 
         print('\n')
     if args.verbose:

--- a/scripts/validator-info
+++ b/scripts/validator-info
@@ -580,7 +580,7 @@ def get_stats_from_file(fpath, verbose, _json, _nagios):
     if _json:
         return json.dumps(vstats, indent=2, cls=NewEncoder)
     if _nagios:
-        return nagios(vstats)
+        return nagios(vstats) 
 
     return vstats
 


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

The new option '--nagios' to validator-info produces output like:

> 0 tlabs_Total_Config_Transactions config_transactions=0 tlabs Total Config Transactions
> 0 tlabs_Total_Ledger_Transactions ledger_transactions=4 tlabs Total Ledger Transactions
> 0 tlabs_Total_Pool_Transactions pool_transactions=3 tlabs Total Pool Transactions
> 0 tlabs_Read_Transactions_per_second read_transactions_per_second=0.00 tlabs Read Transactions/Second
> 0 tlabs_Write_Transactions_per_second write_transactions_per_second=0.00 tlabs Write Transactions/Second
> 0 tlabs_Number_of_Validators number_of_validators=3 tlabs Number of Validators
> 0 tlabs_Reachable_Validators reachable_validators=3 tlabs Reachable Validators
> 0 tlabs_Unreachable_Validators unreachable_validators=0 tlabs Unreachable Validators

On your node 'tlabs' is replaced by the name of the validator.

This output is compatible to Nagios. T-Labs uses it to monitor its Indy nodes with check_mk