### PR TITLE
Deprecated Vagrant method for running test network

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ to understand what needs to be done to create a Network, initialize and start No
 
 The described process is automated in one of the ways below (it allow to install a test Network):
 
- - **Automated VM Creation with Vagrant** [Create virtual machines](environment/vagrant/training/vb-multi-vm/TestIndyClusterSetup.md) using VirtualBox and Vagrant.
-
  - **Docker** [Start Pool and Client with Docker](environment/docker/pool/README.md)
 
  - **Docker-based pool using with new libindy-based CLI**:

--- a/environment/README.md
+++ b/environment/README.md
@@ -3,17 +3,21 @@ Methods and scripts for standing up Indy test environments for different use-cas
 
 The following are among the methods that can be used to set up a Indy Validator cluster for testing.  Others will be implemented in the future.
 
- - [CloudFormation, multiple VMs](#cloudformation)
- - [Vagrant, multiple VMs](#vagrant)
  - [Docker, multiple Containers](#docker)
+ - [CloudFormation, multiple VMs](#cloudformation)
+ - [Vagrant, multiple VMs (deprecated)](#vagrant)
 
 ## CloudFormation
 Using the CloudFormation scripts, an admininstrator can create VPCs and VMs in AWS EC2. The scripts automate configuration tasks such as networking, installation of packages, and configuration of Indy Validator, Agent, and CLI client nodes.  The administrator must have an existing AWS account with adequate permissions, where he will paste in the CloudFormation script, modify it as necessary, and execute it.
-## Vagrant
-Using the Vagrant and bash scripts, an administrator can create VMs in his own PC (Linux, Mac, or Windows), provided that it has adequate storage, memory, and CPU cores.  The scripts automate installation and configuration of Indy software on the VMs, creating Indy Validator, Agent, and CLI client nodes.  Freely available VirtualBox and Vagrant software must be installed before executing these scripts.  The "[TestIndyClusterSetup.md](vagrant/training/vb-multi-vm/TestIndyClusterSetup.md)" file in the vagrant/training/vb-multi-vm/ directory documents the installation and use of the Vagrant scripts.
 
 ## Docker
 Using the Docker configuration and bash scripts, you can build and run Indy containers on your own PC (Linux, Mac, or Windows) docker environment, provided that it has adequate storage, memory, and CPU cores. The scripts automate the docker build process for Indy node and client images, and the steps for running the communicating containers. The only prerequisite is having a Docker installation running before executing the scripts. See the [ReadMe](docker/pool/README.md) for how to run the scripts, with additional details on starting the Agents (Faber College, etc.) needed for completing the Indy Tutorial - Alice and her Transcripts, Job, and Bank Applications.
 
 ## Util
 A collection of utilities/scripts intended to be reused/reusable by all Indy environments. TODO: Decide how these utilities/scripts will be organized. It may be helpful to create a directory structure (component taxonomy/namespace) that aids in discovery.
+
+## Vagrant
+**Warning, this method has been deprecated and is no longer supported.** Using the Vagrant and bash scripts, an administrator can create VMs in his own PC (Linux, Mac, or Windows), provided that it has adequate storage, memory, and CPU cores.  The scripts automate installation and configuration of Indy software on the VMs, creating Indy Validator, Agent, and CLI client nodes.  Freely available VirtualBox and Vagrant software must be installed before executing these scripts.  The "[TestIndyClusterSetup.md](vagrant/training/vb-multi-vm/TestIndyClusterSetup.md)" file in the vagrant/training/vb-multi-vm/ directory documents the installation and use of the Vagrant scripts.
+
+
+

--- a/environment/vagrant/README.md
+++ b/environment/vagrant/README.md
@@ -1,0 +1,1 @@
+**NOTE:** Using Vagrant has been deprecated; Docker is the supported method of running a test network.

--- a/getting-started.md
+++ b/getting-started.md
@@ -3,8 +3,6 @@
 
 ## A Developer Guide for an Implementation of the Indy Code Base
 
-**Note:** If you're looking to create an actual Developer Environment connected to a sandbox, please visit this [guide](https://github.com/hyperledger/indy-node/blob/master/environment/vagrant/sandbox/DevelopmentEnvironment/Virtualbox/Vagrantfile) instead.
-
 ![logo](collateral/logos/indy-logo.png)
 
 * [Getting Started with Indy](#getting-started-with-indy)
@@ -59,8 +57,6 @@ For this guide, however, we’ll be using a command-line interface instead of an
 ## Install Indy
 
 You can install a test network in one of several ways:
-
- - **Automated VM Creation with Vagrant** [Create virtual machines](environment/vagrant/training/vb-multi-vm/TestIndyClusterSetup.md) using VirtualBox and Vagrant.
 
  - **Docker:** [Start Pool and Client with Docker](environment/docker/pool/StartIndyAgents.md).
 


### PR DESCRIPTION
To install and run a test network of nodes on one's computer for development purposes, there are several methods available to use. However, lately only Docker has been supported. Vagrant is more difficult to use, and in many cases breaks completely. Several new, interested developers have been caught trying to use Vagrant and failing because they should be following the more-updated Docker instructions instead.

To fix this problem, Vagrant needs to be marked as deprecated in various places in indy-node's Github repository.

Signed-off-by: ryanwest6 <31378238+ryanwest6@users.noreply.github.com>