### PR TITLE
INDY-1447: Fixed handling of forced requests

### DIFF
--- a/indy_node/server/action_req_handler.py
+++ b/indy_node/server/action_req_handler.py
@@ -69,7 +69,7 @@ class ActionReqHandler(RequestHandler):
                      .format(req.reqId, req.txn_type))
         try:
             if req.txn_type == POOL_RESTART:
-                self.restarter.handleActionTxn(req)
+                self.restarter.handleRestartRequest(req)
                 result = self._generate_action_result(req)
             elif req.txn_type == VALIDATOR_INFO:
                 result = self._generate_action_result(req)

--- a/indy_node/server/config_req_handler.py
+++ b/indy_node/server/config_req_handler.py
@@ -125,12 +125,12 @@ class ConfigReqHandler(LedgerRequestHandler):
             # If it is forced then it was handled earlier
             # in applyForced method.
             if not is_forced(txn):
-                self.upgrader.handleActionTxn(txn)
+                self.upgrader.handleUpgradeTxn(txn)
                 self.poolCfg.handleConfigTxn(txn)
         return committedTxns
 
     def applyForced(self, req: Request):
-        if req.isForced():
-            txn = reqToTxn(req)
-            self.upgrader.handleActionTxn(txn)
-            self.poolCfg.handleConfigTxn(txn)
+        super().applyForced(req)
+        txn = reqToTxn(req)
+        self.upgrader.handleUpgradeTxn(txn)
+        self.poolCfg.handleConfigTxn(txn)

--- a/indy_node/server/node.py
+++ b/indy_node/server/node.py
@@ -297,7 +297,7 @@ class Node(PlenumNode, HasPoolManager):
         c += self.restarter.service()
         return c
 
-    def is_writable(self, txn_type):
+    def is_txn_writable(self, txn_type):
         return self.poolCfg.isWritable() or txn_type in [POOL_UPGRADE, POOL_CONFIG]
 
     def executeDomainTxns(self, ppTime, reqs: List[Request], stateRoot,

--- a/indy_node/server/node.py
+++ b/indy_node/server/node.py
@@ -8,15 +8,13 @@ from indy_node.server.validator_info_tool import ValidatorNodeInfoTool
 
 from plenum.common.constants import VERSION, NODE_PRIMARY_STORAGE_SUFFIX, \
     ENC, RAW, DOMAIN_LEDGER_ID, CURRENT_PROTOCOL_VERSION
-from plenum.common.exceptions import InvalidClientRequest
 from plenum.common.ledger import Ledger
-from plenum.common.messages.node_messages import Reply
 from plenum.common.txn_util import get_type, get_payload_data, TxnUtilConfig
 from plenum.common.types import f, \
     OPERATION
 from plenum.persistence.storage import initStorage
 from plenum.server.node import Node as PlenumNode
-from storage.helper import initKeyValueStorage, initKeyValueStorageIntKeys
+from storage.helper import initKeyValueStorage
 from indy_common.config_util import getConfig
 from indy_common.constants import TXN_TYPE, ATTRIB, DATA, ACTION, \
     NODE_UPGRADE, COMPLETE, FAIL, CONFIG_LEDGER_ID, POOL_UPGRADE, POOL_CONFIG, \
@@ -25,7 +23,6 @@ from indy_common.types import Request, SafeRequest
 from indy_common.config_helper import NodeConfigHelper
 from indy_node.persistence.attribute_store import AttributeStore
 from indy_node.persistence.idr_cache import IdrCache
-from storage.state_ts_store import StateTsDbStorage
 from indy_node.server.client_authn import LedgerBasedAuthNr
 from indy_node.server.config_req_handler import ConfigReqHandler
 from indy_node.server.domain_req_handler import DomainReqHandler
@@ -300,30 +297,8 @@ class Node(PlenumNode, HasPoolManager):
         c += self.restarter.service()
         return c
 
-    def processRequest(self, request: Request, frm: str):
-        if self.is_query(request.operation[TXN_TYPE]):
-            self.process_query(request, frm)
-            self.total_read_request_number += 1
-        elif self.is_action(request.operation[TXN_TYPE]):
-            self.process_action(request, frm)
-        else:
-            # forced request should be processed before consensus
-            if (request.operation[TXN_TYPE] in [
-                    POOL_UPGRADE, POOL_CONFIG]) and request.isForced():
-                self.configReqHandler.validate(request)
-                self.configReqHandler.applyForced(request)
-            # here we should have write transactions that should be processed
-            # pool_restart should not be written to ledger
-            # only on writable pool
-            if self.poolCfg.isWritable() or (request.operation[TXN_TYPE] in [
-                    POOL_UPGRADE, POOL_CONFIG]):
-                super().processRequest(request, frm)
-
-            else:
-                raise InvalidClientRequest(
-                    request.identifier,
-                    request.reqId,
-                    'Pool is in readonly mode, try again in 60 seconds')
+    def is_writable(self, txn_type):
+        return self.poolCfg.isWritable() or txn_type in [POOL_UPGRADE, POOL_CONFIG]
 
     def executeDomainTxns(self, ppTime, reqs: List[Request], stateRoot,
                           txnRoot) -> List:

--- a/indy_node/server/restarter.py
+++ b/indy_node/server/restarter.py
@@ -56,7 +56,7 @@ class Restarter(NodeMaintainer):
             "Restart of node '{}' scheduled on {} "
             "completed successfully".format(self.nodeName, when))
 
-    def handleActionTxn(self, req: Request) -> None:
+    def handleRestartRequest(self, req: Request) -> None:
         """
         Handles transaction of type POOL_RESTART
         Can schedule or cancel restart to a newer

--- a/indy_node/server/upgrader.py
+++ b/indy_node/server/upgrader.py
@@ -185,7 +185,7 @@ class Upgrader(NodeMaintainer):
                     self, last_pool_upgrade_txn_cancel))
                 return
 
-            self.handleActionTxn(last_pool_upgrade_txn_start)
+            self.handleUpgradeTxn(last_pool_upgrade_txn_start)
 
     @property
     def didLastExecutedUpgradeSucceeded(self) -> bool:
@@ -203,7 +203,7 @@ class Upgrader(NodeMaintainer):
             return self.compareVersions(currentVersion, scheduledVersion) == 0
         return False
 
-    def handleActionTxn(self, txn) -> None:
+    def handleUpgradeTxn(self, txn) -> None:
         """
         Handles transaction of type POOL_UPGRADE
         Can schedule or cancel upgrade to a newer

--- a/indy_node/test/helper.py
+++ b/indy_node/test/helper.py
@@ -60,8 +60,9 @@ class TestUpgrader(Upgrader):
              Node.reportSuspiciousNode, Node.reportSuspiciousClient,
              Node.processRequest, Node.processPropagate, Node.propagate,
              Node.forward, Node.send, Node.checkPerformance,
-             Node.getReplyFromLedger, Node.no_more_catchups_needed,
-             Node.onBatchCreated, Node.onBatchRejected])
+             Node.getReplyFromLedger, Node.getReplyFromLedgerForRequest,
+             Node.no_more_catchups_needed, Node.onBatchCreated,
+             Node.onBatchRejected])
 class TestNode(TempStorage, TestNodeCore, Node):
     def __init__(self, *args, **kwargs):
         from plenum.common.stacks import nodeStackClass, clientStackClass

--- a/indy_node/test/upgrade/test_forced_upgrade_if_ordered_and_then_request_received.py
+++ b/indy_node/test/upgrade/test_forced_upgrade_if_ordered_and_then_request_received.py
@@ -1,0 +1,37 @@
+from indy_node.server.upgrade_log import UpgradeLog
+from indy_node.test import waits
+from indy_node.test.upgrade.helper import checkUpgradeScheduled, \
+    sdk_ensure_upgrade_sent
+from plenum.common.constants import VERSION
+from plenum.test.delayers import req_delay
+from plenum.test.test_node import getNonPrimaryReplicas
+from stp_core.loop.eventually import eventually
+
+
+def test_forced_upgrade_handled_once_if_ordered_and_then_request_received(
+        looper, nodeSet, sdk_pool_handle, sdk_wallet_trustee,
+        validUpgradeExpForceTrue):
+    """
+    Verifies that POOL_UPGRADE force=true request is handled one time in case
+    the node commits the transaction to the ledger and only after that receives
+    the request directly from the client
+    """
+    slow_node = getNonPrimaryReplicas(nodeSet, instId=0)[-1].node
+    slow_node.clientIbStasher.delay(req_delay())
+
+    sdk_ensure_upgrade_sent(looper, sdk_pool_handle, sdk_wallet_trustee,
+                            validUpgradeExpForceTrue)
+
+    looper.run(eventually(checkUpgradeScheduled,
+                          [slow_node],
+                          validUpgradeExpForceTrue[VERSION],
+                          retryWait=1,
+                          timeout=waits.expectedUpgradeScheduled()))
+
+    slow_node.clientIbStasher.reset_delays_and_process_delayeds()
+    looper.runFor(waits.expectedUpgradeScheduled())
+
+    checkUpgradeScheduled([slow_node], validUpgradeExpForceTrue[VERSION])
+    assert len(list(slow_node.upgrader._actionLog)) == 1
+    assert slow_node.upgrader._actionLog.lastEvent[1] == \
+           UpgradeLog.SCHEDULED

--- a/indy_node/test/upgrade/test_forced_upgrade_if_request_received_after_propagate.py
+++ b/indy_node/test/upgrade/test_forced_upgrade_if_request_received_after_propagate.py
@@ -1,0 +1,50 @@
+from indy_node.server.upgrade_log import UpgradeLog
+from indy_node.test import waits
+from indy_node.test.upgrade.helper import checkUpgradeScheduled, \
+    sdk_ensure_upgrade_sent
+from plenum.common.constants import VERSION
+from plenum.common.messages.node_messages import Propagate
+from plenum.common.request import Request
+from plenum.test.delayers import req_delay, ppgDelay
+from plenum.test.test_node import getNonPrimaryReplicas
+
+
+def test_forced_upgrade_handled_once_if_request_received_after_propagate(
+        looper, nodeSet, sdk_pool_handle, sdk_wallet_trustee,
+        validUpgradeExpForceTrue):
+    """
+    Verifies that POOL_UPGRADE force=true request is handled one time in case
+    the node commits the transaction to the ledger but during the 3PC-process
+    receives the request directly from the client after a PROPAGATE from some
+    other node
+    """
+    slow_node = getNonPrimaryReplicas(nodeSet, instId=0)[-1].node
+
+    slow_node.clientIbStasher.delay(req_delay())
+    slow_node.nodeIbStasher.delay(ppgDelay(sender_filter='Beta'))
+    slow_node.nodeIbStasher.delay(ppgDelay(sender_filter='Gamma'))
+
+    original_process_propagate = slow_node.nodeMsgRouter.routes[Propagate]
+    original_process_request = slow_node.clientMsgRouter.routes[Request]
+
+    def patched_process_propagate(msg: Propagate, frm: str):
+        original_process_propagate(msg, frm)
+        slow_node.clientIbStasher.reset_delays_and_process_delayeds()
+        slow_node.nodeMsgRouter.routes[Propagate] = original_process_propagate
+
+    def patched_process_request(request: Request, frm: str):
+        original_process_request(request, frm)
+        slow_node.nodeIbStasher.reset_delays_and_process_delayeds()
+        slow_node.clientMsgRouter.routes[Request] = original_process_request
+
+    slow_node.nodeMsgRouter.routes[Propagate] = patched_process_propagate
+    slow_node.clientMsgRouter.routes[Request] = patched_process_request
+
+    sdk_ensure_upgrade_sent(looper, sdk_pool_handle, sdk_wallet_trustee,
+                            validUpgradeExpForceTrue)
+
+    looper.runFor(waits.expectedUpgradeScheduled())
+
+    checkUpgradeScheduled([slow_node], validUpgradeExpForceTrue[VERSION])
+    assert len(list(slow_node.upgrader._actionLog)) == 1
+    assert slow_node.upgrader._actionLog.lastEvent[1] == UpgradeLog.SCHEDULED

--- a/indy_node/test/upgrade/test_node_handles_forced_upgrade_on_client_request.py
+++ b/indy_node/test/upgrade/test_node_handles_forced_upgrade_on_client_request.py
@@ -1,0 +1,32 @@
+from indy_node.test import waits
+from indy_node.test.upgrade.helper import checkUpgradeScheduled, \
+    sdk_send_upgrade
+from plenum.common.constants import VERSION
+from plenum.test.delayers import ppDelay, pDelay, cDelay, ppgDelay
+from plenum.test.test_node import getNonPrimaryReplicas
+from stp_core.loop.eventually import eventually
+
+
+def test_node_handles_forced_upgrade_on_client_request(
+        looper, nodeSet, sdk_pool_handle, sdk_wallet_trustee,
+        validUpgradeExpForceTrue):
+    """
+    Verifies that POOL_UPGRADE force=true request is handled immediately when
+    the node receives it directly from the client
+    """
+    slow_node = getNonPrimaryReplicas(nodeSet, instId=0)[-1].node
+
+    # Stash all except client requests
+    slow_node.nodeIbStasher.delay(ppgDelay())
+    slow_node.nodeIbStasher.delay(ppDelay())
+    slow_node.nodeIbStasher.delay(pDelay())
+    slow_node.nodeIbStasher.delay(cDelay())
+
+    sdk_send_upgrade(looper, sdk_pool_handle, sdk_wallet_trustee,
+                     validUpgradeExpForceTrue)
+
+    looper.run(eventually(checkUpgradeScheduled,
+                          [slow_node],
+                          validUpgradeExpForceTrue[VERSION],
+                          retryWait=1,
+                          timeout=waits.expectedUpgradeScheduled()))

--- a/indy_node/test/upgrade/test_node_handles_forced_upgrade_on_propagate.py
+++ b/indy_node/test/upgrade/test_node_handles_forced_upgrade_on_propagate.py
@@ -1,0 +1,34 @@
+from indy_node.test import waits
+from indy_node.test.upgrade.helper import checkUpgradeScheduled, \
+    sdk_send_upgrade
+from plenum.common.constants import VERSION
+from plenum.test.delayers import req_delay, ppDelay, pDelay, cDelay, ppgDelay
+from plenum.test.test_node import getNonPrimaryReplicas
+from stp_core.loop.eventually import eventually
+
+
+def test_node_handles_forced_upgrade_on_propagate(
+        looper, nodeSet, sdk_pool_handle, sdk_wallet_trustee,
+        validUpgradeExpForceTrue):
+    """
+    Verifies that POOL_UPGRADE force=true request is handled immediately when
+    the node receives it in a PROPAGATE from any other node
+    """
+    slow_node = getNonPrimaryReplicas(nodeSet, instId=0)[-1].node
+
+    # Stash all except propagates from Alpha
+    slow_node.clientIbStasher.delay(req_delay())
+    slow_node.nodeIbStasher.delay(ppgDelay(sender_filter='Alpha'))
+    slow_node.nodeIbStasher.delay(ppgDelay(sender_filter='Beta'))
+    slow_node.nodeIbStasher.delay(ppDelay())
+    slow_node.nodeIbStasher.delay(pDelay())
+    slow_node.nodeIbStasher.delay(cDelay())
+
+    sdk_send_upgrade(looper, sdk_pool_handle, sdk_wallet_trustee,
+                     validUpgradeExpForceTrue)
+
+    looper.run(eventually(checkUpgradeScheduled,
+                          [slow_node],
+                          validUpgradeExpForceTrue[VERSION],
+                          retryWait=1,
+                          timeout=waits.expectedUpgradeScheduled()))

--- a/indy_node/test/upgrade/test_node_handles_forced_upgrade_on_propagate.py
+++ b/indy_node/test/upgrade/test_node_handles_forced_upgrade_on_propagate.py
@@ -16,7 +16,7 @@ def test_node_handles_forced_upgrade_on_propagate(
     """
     slow_node = getNonPrimaryReplicas(nodeSet, instId=0)[-1].node
 
-    # Stash all except propagates from Alpha
+    # Stash all except PROPAGATEs from Gamma
     slow_node.clientIbStasher.delay(req_delay())
     slow_node.nodeIbStasher.delay(ppgDelay(sender_filter='Alpha'))
     slow_node.nodeIbStasher.delay(ppgDelay(sender_filter='Beta'))

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum-dev==1.4.452',
+    install_requires=['indy-plenum-dev==1.4.459',
                       'indy-anoncreds-dev==1.0.32',
                       'python-dateutil',
                       'timeout-decorator==0.4.0'],


### PR DESCRIPTION
- Added tests verifying different cases of handling of `POOL_UPGRADE force=true` request.
- Provided `Node.is_txn_writable` method implementation for indy-node.
- Renamed `handleActionTxn` methods in `Upgrader` and `Restarter` classes using different names since they do not use common interface.