### PR TITLE
Add 2 steward utility files

### DIFF
--- a/scripts/current_validators
+++ b/scripts/current_validators
@@ -1,0 +1,138 @@
+#!/usr/bin/python3
+
+import string
+import json
+import csv
+import logging
+import argparse
+import subprocess
+import sys
+import collections
+
+logging.basicConfig(
+         format='%(asctime)s %(levelname)-8s %(message)s',
+         level=logging.INFO,
+         filename='current_validators.log',
+         datefmt='%Y-%m-%d %H:%M:%S')
+
+
+def parseTransactions(ledger):
+
+    logging.info("Parsing ledger transactions into dictionary")
+
+    validators = collections.OrderedDict()
+    # validators is dictionary of dictionaries that maps dest to the current values of the attritubes for that dest
+    #  { dest1:{'alias':value1, 'blskey':value1, ...} , dest2:{'alias':value2, 'blskey':value2, ...}, ...}
+
+    for lLine in ledger:
+        txn_json_dump = json.loads(lLine)
+
+        if (txn_json_dump[1]['dest'] is None ) :
+            break
+        else:
+            # Get destination field from the JSON dump of the current transaction
+            current_dest = txn_json_dump[1]['dest']
+
+            data_json_dump = txn_json_dump[1]['data']
+
+            # Add destination to the dictionary if it does not exist
+            if not( current_dest in validators.keys() ):
+                validators[ current_dest ] = {}
+
+            # Update attribute value of the destination if the attributes exists in the current transaction dump
+            try:
+                validators[current_dest]['alias']  = data_json_dump['alias']
+            except KeyError:
+                pass
+            try:
+                validators[current_dest]['blskey']  = data_json_dump['blskey']
+            except KeyError:
+                pass
+            try:
+                validators[current_dest]['client_ip']  = data_json_dump['client_ip']
+            except KeyError:
+                pass
+            try:
+                validators[current_dest]['client_port']  = data_json_dump['client_port']
+            except KeyError:
+                pass
+            try:
+                validators[current_dest]['node_ip']  = data_json_dump['node_ip']
+            except KeyError:
+                pass
+            try:
+                validators[current_dest]['node_port']  = data_json_dump['node_port']
+            except KeyError:
+                pass
+            try:
+                validators[current_dest]['services']  = data_json_dump['services']
+            except KeyError:
+                pass
+            if 'identifier' not in validators[current_dest]:
+                try:
+                    validators[current_dest]['identifier']  = txn_json_dump[1]['identifier']
+                except KeyError:
+                    pass
+            validators[current_dest]['dest']  = current_dest
+
+    return validators
+
+
+def getLedger():
+    try:
+        completed = subprocess.run(
+        ['sudo', '/usr/local/bin/read_ledger', '--type', 'pool', '--count'],
+        check=True,
+        stdout=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as err:
+        logger.error('ERROR attempting to run read_ledger --count subprocess: {}'.format(err))
+        raise
+    transCount = completed.stdout.decode('utf-8').strip()
+    logging.info("{} entries in ledger.".format(transCount))
+    try:
+        completed = subprocess.run(
+        ['sudo', '/usr/local/bin/read_ledger', '--type', 'pool', '--frm', '1', '--to', completed.stdout],
+        check=True,
+        stdout=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as err:
+        logger.error('ERROR attempting to run read_ledger subprocess to capture ledger data: {}'.format(err))
+        raise
+
+    ledgerLines = completed.stdout.decode('utf-8').splitlines()
+    logging.info("{} ledger entries received.".format(len(ledgerLines)))
+    return ledgerLines
+
+def writeResult(jsonOut):
+
+    if jsonOut:
+        logging.info("Serializing info on validators to json")
+        count = len(validators)
+        print('[', end='')
+        for i in validators.keys():
+            print(json.dumps(validators[i], sort_keys=True), end='')
+            if count > 1:
+                print(',', end='')
+                count -= 1
+        print(']')
+    else:
+        logging.info("Serializing info on validators to csv")
+        fieldnames = ['alias', 'blskey', 'client_ip', 'client_port', 'node_ip', 'node_port', 'services', 'dest', 'identifier']
+        writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+        writer.writeheader()
+        for i in validators.keys():
+            writer.writerow(validators[i])
+
+def parseInputs():
+    parser = argparse.ArgumentParser(description = 'This script may be run on a validator node to discover information on all the validators configured in the ledger.')
+    parser.add_argument('--writeJson', help='Boolean flag.  If set, the output is json. (Default: the output is csv.)', action='store_true')
+    args = parser.parse_args()
+    return args.writeJson
+
+
+if __name__ == '__main__':
+    writeJson = parseInputs()
+    ledger = getLedger()
+    validators = parseTransactions(ledger)
+    writeResult = writeResult(writeJson)

--- a/scripts/node_address_list
+++ b/scripts/node_address_list
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+
+import string
+import json
+import logging
+import argparse
+import sys
+import fileinput
+import csv
+import collections
+
+logging.basicConfig(
+         format='%(asctime)s %(levelname)-8s %(message)s',
+         level=logging.INFO,
+         filename='node_address_list.log',
+         datefmt='%Y-%m-%d %H:%M:%S')
+
+
+
+def getCurrentValidatorsAddressPort():
+    logging.info("extracting addresses and ports of current validators")
+    validatorsAddressPort = collections.OrderedDict()
+    jsonStr = input()
+    logging.info(jsonStr)
+    validators = json.loads(jsonStr)
+    for validator in validators:
+        if 'VALIDATOR' in validator['services']:
+            validatorsAddressPort[validator["alias"]] = {"address": validator["node_ip"], "port": validator["node_port"]}
+    return validatorsAddressPort
+
+def writeResult(validatorsAddressPort, outputFormat):
+    if outputFormat == 'json':
+        logging.info("Serializing validators' address and port to json")
+        print(json.dumps(validatorsAddressPort))
+    elif outputFormat == 'aws':
+        logging.info("Writing a string suitable for a source string for an AWS security group")
+        addressOnly = []
+        for key in validatorsAddressPort.keys():
+            addressOnly.append(validatorsAddressPort[key]['address'])
+        conjunction = '/32,'
+        print(conjunction.join(addressOnly) + '/32')
+    else:
+        logging.info("Serializing validators' address and port to csv")
+        fieldnames = ['alias', 'address', 'port']
+        writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+        writer.writeheader()
+        for key in validatorsAddressPort.keys():
+            validatorsAddressPort[key]["alias"] = key
+            writer.writerow(validatorsAddressPort[key])
+
+def parseInputs():
+    parser = argparse.ArgumentParser(description = 'This script accepts validator JSON data on stdin, and extracts the node address and port information from it.')
+    parser.add_argument('--outFormat', help='May be json, csv, or aws. (Default: the output is csv.)')
+    args = parser.parse_args()
+    if args.outFormat == None:
+        return 'csv'
+    elif args.outFormat in ['csv', 'json', 'aws']:
+        return args.outFormat
+    else:
+        print('Invalid output format selected: {}'.format(args.outFormat))
+        exit(1)
+
+
+if __name__ == '__main__':
+    outputFormat = parseInputs()
+    validatorsAddressPort = getCurrentValidatorsAddressPort()
+    writeResult = writeResult(validatorsAddressPort, outputFormat)


### PR DESCRIPTION
current_validators gets the pool ledger from read_ledger, and
parses them to condense the information to the latest valid
entries for each field. Output is to console, as json or as csv.

node_address_list will take the json output from
current_validators and distill it down to just the currently
active validators, and returns to console just the alias and the
node IP address for each, useful for making firewall whitelists.

Signed-off-by: Mike Bailey <mike.bailey@evernym.com>