### PR TITLE
INDY-1741: Bugfix problem with Restarter after scheduled restart 

### DIFF
--- a/indy_node/server/restarter.py
+++ b/indy_node/server/restarter.py
@@ -52,9 +52,6 @@ class Restarter(NodeMaintainer):
         self._actionLog.appendSucceeded(when)
         logger.info("Node '{}' successfully restarted"
                     .format(self.nodeName))
-        self._notifier.sendMessageUponNodeRestartComplete(
-            "Restart of node '{}' scheduled on {} "
-            "completed successfully".format(self.nodeName, when))
 
     def handleRestartRequest(self, req: Request) -> None:
         """
@@ -252,7 +249,6 @@ class Restarter(NodeMaintainer):
         if external_reason:
             logger.error("This problem may have external reasons, "
                          "check syslog for more information")
-        self._notifier.sendMessageUponNodeRestartFail(error_message)
 
 
 class RestartMessage(NodeControlToolMessage):

--- a/indy_node/test/pool_restart/test_pool_restart.py
+++ b/indy_node/test/pool_restart/test_pool_restart.py
@@ -44,10 +44,9 @@ def test_pool_restart(
 
 def test_restarter_can_initialize_after_pool_restart(txnPoolNodeSet):
     '''
-    1. Schedule restart after restart_timeout seconds
-    2. Add restart schedule message to ActionLog
-    3. Add start restart message to ActionLog
-    4. Check that Restarter can be create (emulate case after node restart).
+    1. Add restart schedule message to ActionLog
+    2. Add start restart message to ActionLog
+    3. Check that Restarter can be create (emulate case after node restart).
     '''
     unow = datetime.utcnow().replace(tzinfo=dateutil.tz.tzutc())
     restarted_node = txnPoolNodeSet[-1]

--- a/indy_node/test/pool_restart/test_pool_restart.py
+++ b/indy_node/test/pool_restart/test_pool_restart.py
@@ -11,11 +11,6 @@ from indy_node.server.restarter import Restarter
 from indy_node.test.pool_restart.helper import _createServer, _stopServer, sdk_send_restart
 from plenum.common.constants import REPLY, TXN_TYPE
 from plenum.common.types import f
-from plenum.test.helper import sdk_gen_request, sdk_sign_and_submit_req_obj, \
-    sdk_get_reply, sdk_get_and_check_replies
-from indy_node.test.upgrade.helper import NodeControlToolExecutor as NCT, \
-    nodeControlGeneralMonkeypatching
-from stp_core.loop.eventually import eventually
 
 
 def test_pool_restart(


### PR DESCRIPTION
After scheduled restart in initializing Restarter the method ```_update_action_log_for_started_action``` is called. It has a bug and test test_restarter_can_initialize_after_pool_restart schould detect it.