### PR TITLE
[INDY-1827] Fixes aws_manage role variables relationship

### DIFF
--- a/pool_automation/roles/aws_manage/defaults/main.yml
+++ b/pool_automation/roles/aws_manage/defaults/main.yml
@@ -29,9 +29,9 @@ pa_aws_prefix: PA
 
 # Derivative parameters
 group_name: "{{ aws_tag_role }}s"
-inventory_dir: "{{ aws_tag_namespace }}_{{ group_name }}"
 
-aws_inventory_file: "{{ inventory_dir }}/hosts"
 aws_tag_namespace: "{{ inventory_dir | default('test', true) | basename }}"
+aws_inventory_dir: "{{ inventory_dir | default(aws_tag_namespace ~ '_' ~ group_name) }}"
+aws_inventory_file: "{{ aws_inventory_dir }}/hosts"
 aws_keyname: "{{ pa_aws_prefix }}-{{ aws_tag_namespace }}-{{ group_name }}"
 aws_sgroup: "{{ pa_aws_prefix }}-{{ aws_tag_namespace }}-{{ group_name }}"

--- a/pool_automation/roles/aws_manage/tasks/main.yml
+++ b/pool_automation/roles/aws_manage/tasks/main.yml
@@ -9,7 +9,7 @@
     - aws_tag_role
     - aws_regions
     - group_name
-    - inventory_dir
+    - aws_inventory_dir
     - aws_inventory_file
     - aws_tag_namespace
     - aws_keyname
@@ -21,7 +21,7 @@
 
 - name: Set ssh_dir variable
   set_fact:
-    ssh_dir: "{{ inventory_dir }}/{{ ssh_dir_name }}"
+    ssh_dir: "{{ aws_inventory_dir }}/{{ ssh_dir_name }}"
 
 - name: Check that instance_count has acceptable values
   assert:


### PR DESCRIPTION
The PR fixes an infinite loop in aws_manage defaults when no inventory is defined: 
`aws_inventory_dir` <-> `aws_tag_namespace`