### PR TITLE
[Pool Automation][INDY-1899] Fixes host keys scan routine

### DIFF
--- a/pool_automation/roles/aws_manage/tasks/set_known_hosts.yml
+++ b/pool_automation/roles/aws_manage/tasks/set_known_hosts.yml
@@ -20,7 +20,11 @@
       command: "ssh-keyscan -H {{ item.item }}"
       when: item.rc != 0
       register: host_keys
+      # ssh-keyscan fails silently returning nothing with 0 exit code
       loop: "{{ known_hosts.results }}"
+      until: host_keys.rc == 0 and (not not host_keys.stdout|trim)
+      retries: 5
+      delay: 5
 
     - name: Add host keys into '{{ ssh_known_hosts }}'
       known_hosts:


### PR DESCRIPTION
- ssh-keyscan fails silently, thus need to check its output and retry if nothing has been returned