### PR TITLE
Fix the deprecated option of gnu-sed

### DIFF
--- a/environment/docker/pool/README.md
+++ b/environment/docker/pool/README.md
@@ -1,7 +1,7 @@
 # Prerequisites
 * Docker
 * Current user added to 'docker' group (not needed for all environments)
-* macOS users will need to install an up to date version of sed using Homebrew `brew install gnu-sed --with-default-names`
+* macOS users will need to install an up to date version of sed using Homebrew `brew install gnu-sed`
 
 # Start pool
 ```


### PR DESCRIPTION
The --with-default-names option is removed, so it is not available anymore.

https://github.com/Homebrew/homebrew-core/commit/068955e8cd698ac0286302fd244a4e4b42b47bab