### PR TITLE
Update transaction structure description.

### DIFF
--- a/docs/source/requests-new.md
+++ b/docs/source/requests-new.md
@@ -954,15 +954,8 @@ Adds a new node to the pool, or updates existing node in the pool.
 
 - `did` (base58-encoded string):
 
-    Target Node's DID as base58-encoded string for 16 or 32 bit DID value.
+    Target Node's verkey as base58-encoded string for 16 or 32 byte DID value.
     It differs from `from` metadata field, where `from` is the DID of the transaction submitter (Steward"s DID).
-    
-    *Example*: `from` is a DID of a Steward creating a new Node, and `did` is the DID of this Node.
-    
-- `verkey` (base58-encoded string; optional): 
-
-    Target Node verification key as base58-encoded string.
-    It may absent if `did` is 32-bit cryptonym CID. 
 
 - `alias` (string): 
     

--- a/docs/source/requests.md
+++ b/docs/source/requests.md
@@ -710,15 +710,10 @@ Adds a new node to the pool, or updates existing node in the pool.
 
 - `dest` (base58-encoded string):
 
-    Target Node's DID as base58-encoded string for 16 or 32 byte DID value.
+    Target Node's verkey as base58-encoded string for 16 or 32 byte DID value.
     It differs from `identifier` metadata field, where `identifier` is the DID of the transaction submitter (Steward's DID).
-    
-    *Example*: `identifier` is a DID of a Steward creating a new Node, and `dest` is the DID of this Node.
-    
-- `verkey` (base58-encoded string, possibly starting with "~"; optional):
 
-    Target Node verification key as base58-encoded string.
-    It may absent if `dest` is 32-bit cryptonym CID. 
+    *Example*: `identifier` is a DID of a Steward creating a new Node, and `dest` is the verkey of this Node.
 
 If there is no NODE transaction with the specified Node ID (`dest`), then it can be considered as creation of a new NODE.
 

--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -458,16 +458,10 @@ Adds a new node to the pool or updates an existing node in the pool
 
 - `dest` (base58-encoded string):
 
-    Target Node's DID as base58-encoded string for 16 or 32 byte DID value.
+    Target Node's verkey as base58-encoded string for 16 or 32 byte DID value.
     It differs from `identifier` metadata field, where `identifier` is the DID of the transaction submitter (Steward's DID).
 
-    *Example*: `identifier` is a DID of a Steward creating a new Node, and `dest` is the DID of this Node.
-
-- `verkey` (base58-encoded string, possibly starting with "~"; optional):
-
-    Target Node verification key as base58-encoded string.
-    It may absent if `dest` is 32-bit cryptonym CID.
-
+    *Example*: `identifier` is a DID of a Steward creating a new Node, and `dest` is the verkey of this Node.
 
 If there is no NODE transaction with the specified Node ID (`dest`), then it can be considered as creation of a new NODE.
 


### PR DESCRIPTION
The description of the content of a transaction, and in particular a node transaction, is not consistent with the current workings of indy-node. While in the [transactions README](https://github.com/hyperledger/indy-node/blob/master/docs/source/transactions.md) is stated that the `dest` field of a node transaction is a node DID, it is instead the node verification key (as also shown by the test scripts, where the verification key of the node is written in the pool transaction, and not it public key).