### PR TITLE
INDY-2074: Extend documentation for Auth Rules, TAA and Revocation

### DIFF
--- a/design/txn_author_agreement.md
+++ b/design/txn_author_agreement.md
@@ -111,13 +111,18 @@ How does TAA AML stored in state. "3" stands for unique marker of TAA AML txn.
   <tr>
     <td><code>3:latest</code></td>
     <td>
-<pre>{
-  "aml": {
-    "mechanism #1": description #1,
-    "mechanism #2": description #2
-  },
-  "amlContext": context description,
-  "version": version
+<pre>
+{
+  "lsn": &lt;txn sequence number&gt;,,
+  "lut": timestamp,
+  "val": {
+      "aml": {
+        "mechanism #1": description #1,
+        "mechanism #2": description #2
+      },
+      "amlContext": context description,
+      "version": version
+  }
 }</pre>
     </td>
   </tr>
@@ -125,12 +130,16 @@ How does TAA AML stored in state. "3" stands for unique marker of TAA AML txn.
     <td><code>3:v:&lt;version&gt;</code></td>
     <td>
 <pre>{
-  "aml": {
-    "mechanism #1": description #1,
-    "mechanism #2": description #2
-  },
-  "amlContext": context description,
-  "version": version
+  "lsn": &lt;txn sequence number&gt;,,
+  "lut": timestamp,
+  "val": {
+      "aml": {
+        "mechanism #1": description #1,
+        "mechanism #2": description #2
+      },
+      "amlContext": context description,
+      "version": version
+  }
 }</pre>
     </td>
   </tr>

--- a/docs/source/auth_rules.md
+++ b/docs/source/auth_rules.md
@@ -7,6 +7,7 @@
     <th>Previous value</th>
     <th>New value</th>
     <th>Who can</th>
+    <th>Who is owner</th>
     <th>Description</th>
   </tr>
 
@@ -17,6 +18,7 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>TRUSTEE</sub></td>
     <td><sub>1 TRUSTEE</sub></td>
+    <td><sub>N/A</sub></td>
     <td><sub>Adding a new TRUSTEE</sub></td>
   </tr>
   <tr>
@@ -26,6 +28,7 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>STEWARD</sub></td>
     <td><sub>1 TRUSTEE</sub></td>
+    <td><sub>N/A</sub></td>
     <td><sub>Adding a new STEWARD</sub></td>
   </tr>
   <tr>
@@ -35,6 +38,7 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>TRUST_ANCHOR</sub></td>
     <td><sub>1 TRUSTEE OR 1 STEWARD</sub></td>
+    <td><sub>N/A</sub></td>
     <td><sub>Adding a new TRUST_ANCHOR</sub></td>
   </tr>
   <tr>
@@ -44,6 +48,7 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>NETWORK_MONITOR</sub></td>
     <td><sub>1 TRUSTEE OR 1 STEWARD</sub></td>
+    <td><sub>N/A</sub></td>
     <td><sub>Adding a new NETWORK_MONITOR</sub></td>
   </tr>
   <tr>
@@ -53,6 +58,7 @@
     <td><sub><code>*</code></sub></td>
     <td><sub><code>&lt;None&gt;</code></sub></td>
     <td><sub>1 TRUSTEE OR 1 STEWARD OR 1 TRUST_ANCHOR</sub></td>
+    <td><sub>N/A</sub></td>
     <td><sub>Adding a new Identity Owner</sub></td>
   </tr>
 
@@ -63,6 +69,7 @@
     <td><sub>TRUSTEE</sub></td>
     <td><sub>STEWARD</sub></td>
     <td><sub>1 TRUSTEE</sub></td>
+    <td><sub></sub></td>
     <td><sub>Changing Trustee to Steward</sub></td>
   </tr>
   <tr>

--- a/docs/source/auth_rules.md
+++ b/docs/source/auth_rules.md
@@ -303,6 +303,42 @@
     <td><sub>1 owner TRUSTEE OR 1 owner STEWARD OR 1 owner TRUST_ANCHOR</sub></td>
     <td><sub>Editing a CLAIM_DEF: INDY-2078 - can not be configured by auth rule; ADD CLAIM_DEF rule is currently used for editing where owner is always true as it's part of the primary key</sub></td>
   </tr>
+    <tr>
+    <td><sub>REVOC_REG_DEF</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub>1 TRUSTEE OR 1 STEWARD OR 1 TRUST_ANCHOR</sub></td>
+    <td><sub>Adding a new REVOC_REG_DEF</sub></td>
+  </tr>
+  <tr>
+    <td><sub>REVOC_REG_DEF</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub>1 any (*) role owner</sub></td>
+    <td><sub>Editing a REVOC_REG_DEF</sub></td>
+  </tr>
+  <tr>
+    <td><sub>REVOC_REG_ENTRY</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub>1 any (*) role owner of the corresponding REVOC_REG_DEF</sub></td>
+    <td><sub>Adding a new REVOC_REG_ENTRY</sub></td>
+  </tr>
+  <tr>
+    <td><sub>REVOC_REG_ENTRY</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub>1 any (*) role owner</sub></td>
+    <td><sub>Editing a REVOC_REG_ENTRY</sub></td>
+  </tr>  
   <tr>
     <td><sub>NODE</sub></td>
     <td><sub>ADD</sub></td>
@@ -430,6 +466,24 @@
     <td><sub>Changing an authentification rule</sub></td>
   </tr>
   <tr>
+    <td><sub>TRANSACTION_AUTHOR_AGREEMENT</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub>1 TRUSTEE</sub></td>
+    <td><sub>Adding a new Transaction Author Agreement</sub></td>
+  </tr>    
+  <tr>
+    <td><sub>TRANSACTION_AUTHOR_AGREEMENT_AML</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub><code>*</code></sub></td>
+    <td><sub>1 TRUSTEE</sub></td>
+    <td><sub>Adding a new Transaction Author Agreement Mechanism List</sub></td>
+  </tr>      
+  <tr>
     <td><sub>VALIDATOR_INFO</sub></td>
     <td><sub>ADD</sub></td>
     <td><sub><code>*</code></sub></td>
@@ -437,42 +491,6 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>1 TRUSTEE OR 1 STEWARD OR 1 NETWORK_MONITOR</sub></td>
     <td><sub>Getting validator_info from pool</sub></td>
-  </tr>
-    <tr>
-    <td><sub>REVOC_REG_DEF</sub></td>
-    <td><sub>ADD</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 TRUSTEE OR 1 STEWARD OR 1 TRUST_ANCHOR</sub></td>
-    <td><sub>Adding a new REVOC_REG_DEF</sub></td>
-  </tr>
-  <tr>
-    <td><sub>REVOC_REG_DEF</sub></td>
-    <td><sub>EDIT</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any (*) role owner</sub></td>
-    <td><sub>Editing a REVOC_REG_DEF</sub></td>
-  </tr>
-  <tr>
-    <td><sub>REVOC_REG_ENTRY</sub></td>
-    <td><sub>ADD</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any (*) role owner of the corresponding REVOC_REG_DEF</sub></td>
-    <td><sub>Adding a new REVOC_REG_ENTRY</sub></td>
-  </tr>
-  <tr>
-    <td><sub>REVOC_REG_ENTRY</sub></td>
-    <td><sub>EDIT</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any (*) role owner</sub></td>
-    <td><sub>Editing a REVOC_REG_ENTRY</sub></td>
   </tr>
 </table>
 
@@ -637,21 +655,10 @@
   </tr>    
 
   <tr>
-    <td><sub>TRANSACTION_AUTHOR_AGREEMENT</sub></td>
-    <td><sub>EDIT</sub></td>
-    <td><sub>N/A</sub></td>
-  </tr>   
-
-  <tr>
     <td><sub>TRANSACTION_AUTHOR_AGREEMENT_AML</sub></td>
     <td><sub>ADD</sub></td>
     <td><sub>N/A</sub></td>
   </tr>    
 
-  <tr>
-    <td><sub>TRANSACTION_AUTHOR_AGREEMENT_AML</sub></td>
-    <td><sub>EDIT</sub></td>
-    <td><sub>N/A</sub></td>
-  </tr>  
         
 </table>  

--- a/docs/source/auth_rules.md
+++ b/docs/source/auth_rules.md
@@ -7,7 +7,6 @@
     <th>Previous value</th>
     <th>New value</th>
     <th>Who can</th>
-    <th>Who is owner</th>
     <th>Description</th>
   </tr>
 
@@ -18,7 +17,6 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>TRUSTEE</sub></td>
     <td><sub>1 TRUSTEE</sub></td>
-    <td><sub>N/A</sub></td>
     <td><sub>Adding a new TRUSTEE</sub></td>
   </tr>
   <tr>
@@ -28,7 +26,6 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>STEWARD</sub></td>
     <td><sub>1 TRUSTEE</sub></td>
-    <td><sub>N/A</sub></td>
     <td><sub>Adding a new STEWARD</sub></td>
   </tr>
   <tr>
@@ -38,7 +35,6 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>TRUST_ANCHOR</sub></td>
     <td><sub>1 TRUSTEE OR 1 STEWARD</sub></td>
-    <td><sub>N/A</sub></td>
     <td><sub>Adding a new TRUST_ANCHOR</sub></td>
   </tr>
   <tr>
@@ -48,7 +44,6 @@
     <td><sub><code>*</code></sub></td>
     <td><sub>NETWORK_MONITOR</sub></td>
     <td><sub>1 TRUSTEE OR 1 STEWARD</sub></td>
-    <td><sub>N/A</sub></td>
     <td><sub>Adding a new NETWORK_MONITOR</sub></td>
   </tr>
   <tr>
@@ -58,7 +53,6 @@
     <td><sub><code>*</code></sub></td>
     <td><sub><code>&lt;None&gt;</code></sub></td>
     <td><sub>1 TRUSTEE OR 1 STEWARD OR 1 TRUST_ANCHOR</sub></td>
-    <td><sub>N/A</sub></td>
     <td><sub>Adding a new Identity Owner</sub></td>
   </tr>
 
@@ -69,7 +63,6 @@
     <td><sub>TRUSTEE</sub></td>
     <td><sub>STEWARD</sub></td>
     <td><sub>1 TRUSTEE</sub></td>
-    <td><sub></sub></td>
     <td><sub>Changing Trustee to Steward</sub></td>
   </tr>
   <tr>
@@ -483,115 +476,182 @@
   </tr>
 </table>
 
-### Also, there are optional rules for case of ANYONE_CAN_WRITE set to True in config file:
+
+### Who Is Owner
+
 <table class="tg">
   <tr>
-    <th>Transaction type</th>
+    <th>Transaction Type</th>
     <th>Action</th>
-    <th>Field</th>
-    <th>Previous value</th>
-    <th>New value</th>
-    <th>Who can</th>
-    <th>Description</th>
+    <th>Who is Owner</th>
   </tr>
+  
   <tr>
     <td><sub>NYM</sub></td>
     <td><sub>ADD</sub></td>
-    <td><sub><code>role</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>Anyone</sub></td>
-    <td><sub>Adding a new NYM</sub></td>
+    <td><sub>N/A</sub></td>
   </tr>
+
   <tr>
     <td><sub>NYM</sub></td>
     <td><sub>EDIT</sub></td>
-    <td><sub><code>role</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any role (*) role owner</sub></td>
-    <td><sub>Editing a NYM</sub></td>
+    <td><sub>The DID defined by the NYM txn (`dest` field) if `verkey` is set; otherwise the submitter of the NYM txn (`identifier` field)</sub></td>
   </tr>
+  
+  <tr>
+    <td><sub>ATTRIB</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>The owner of the DID (`dest` field) the ATTRIB is created for (see NYM's owner description)</sub></td>
+  </tr>  
+
+  <tr>
+    <td><sub>ATTRIB</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>The owner of the DID (`dest` field) the ATTRIB is created for (see NYM's owner description)</sub></td>
+  </tr>
+  
   <tr>
     <td><sub>SCHEMA</sub></td>
     <td><sub>ADD</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>Anyone</sub></td>
-    <td><sub>Adding a new SCHEMA</sub></td>
-  </tr>
-  <tr>
-    <td><sub>CLAIM_DEF</sub></td>
-    <td><sub>ADD</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>Anyone</sub></td>
-    <td><sub>Adding a new CLAIM_DEF</sub></td>
-  </tr>
-  <tr>
-    <td><sub>CLAIM_DEF</sub></td>
-    <td><sub>EDIT</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any role (*) role owner</sub></td>
-    <td><sub>Editing a new CLAIM_DEF</sub></td>
-  </tr>
-  <tr>
-    <td><sub>ATTRIB</sub></td>
-    <td><sub>ADD</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any role (*) role owner of the corresponding NYM</sub></td>
-    <td><sub>Adding a new ATTRIB</sub></td>
-  </tr>
-  <tr>
-    <td><sub>ATTRIB</sub></td>
-    <td><sub>EDIT</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any role (*) role owner of the corresponding NYM</sub></td>
-    <td><sub>Editing an ATTRIB</sub></td>
-  </tr>
-  <tr>
-    <td><sub>REVOC_REG_DEF</sub></td>
-    <td><sub>ADD</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>Anyone</sub></td>
-    <td><sub>Adding a new REVOC_REG_DEF</sub></td>
-  </tr>
-  <tr>
-    <td><sub>REVOC_REG_DEF</sub></td>
-    <td><sub>EDIT</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any (*) role owner</sub></td>
-    <td><sub>Editing a REVOC_REG_DEF</sub></td>
-  </tr>
-  <tr>
-    <td><sub>REVOC_REG_ENTRY</sub></td>
-    <td><sub>ADD</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any (*) role owner of the corresponding REVOC_REG_DEF</sub></td>
-    <td><sub>Adding a new REVOC_REG_ENTRY</sub></td>
-  </tr>
-  <tr>
-    <td><sub>REVOC_REG_ENTRY</sub></td>
-    <td><sub>EDIT</sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub><code>*</code></sub></td>
-    <td><sub>1 any (*) role owner of the corresponding REVOC_REG_DEF</sub></td>
-    <td><sub>Editing a REVOC_REG_ENTRY</sub></td>
-  </tr>
-</table>
+    <td><sub>N/A</sub></td>
+  </tr>    
 
+  <tr>
+    <td><sub>SCHEMA</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>The DID used to create the SCHEMA</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>CLAIM_DEF</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>CLAIM_DEF</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>The DID used to create the CLAIM_DEF</sub></td>
+  </tr>  
+  
+  <tr>
+    <td><sub>REVOC_REG_DEF</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>REVOC_REG_DEF</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>The DID used to create the REVOC_REG_DEF</sub></td>
+  </tr>    
+  
+  <tr>
+    <td><sub>REVOC_REG_ENTRY</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>The DID used to create the corresponding REVOC_REG_DEF</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>REVOC_REG_ENTRY</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>The DID used to create the REVOC_REG_ENTRY</sub></td>
+  </tr>     
+  
+  <tr>
+    <td><sub>NODE</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>NODE</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>The Steward's DID used to create the NODE</sub></td>
+  </tr>      
+  
+  <tr>
+    <td><sub>POOL_UPGRADE</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>POOL_UPGRADE</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>     
+  
+  <tr>
+    <td><sub>POOL_RESTART</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>POOL_RESTART</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>     
+  
+  <tr>
+    <td><sub>POOL_CONFIG</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>POOL_CONFIG</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>      
+  
+  <tr>
+    <td><sub>VALIDATOR_INFO</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>VALIDATOR_INFO</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+  
+  <tr>
+    <td><sub>AUTH_RULE</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>AUTH_RULE</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>      
+  
+  <tr>
+    <td><sub>TRANSACTION_AUTHOR_AGREEMENT</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>TRANSACTION_AUTHOR_AGREEMENT</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>   
+
+  <tr>
+    <td><sub>TRANSACTION_AUTHOR_AGREEMENT_AML</sub></td>
+    <td><sub>ADD</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>    
+
+  <tr>
+    <td><sub>TRANSACTION_AUTHOR_AGREEMENT_AML</sub></td>
+    <td><sub>EDIT</sub></td>
+    <td><sub>N/A</sub></td>
+  </tr>  
+        
+</table>  

--- a/docs/source/requests.md
+++ b/docs/source/requests.md
@@ -33,7 +33,7 @@
 
 * [Action Requests](#action-requests)
 
-    * [POOL_RESTART](#pool_restrt)
+    * [POOL_RESTART](#pool_restart)
     * [VALIDATOR_INFO](#validator_info)
     
 This doc is about supported client's Request (both write and read ones).
@@ -256,7 +256,7 @@ of a transaction in the Ledger (see [transactions](transactions.md)).
             Unique ID number of the request with transaction.
   
         - `digest` (SHA256 hex digest string):
-            SHA256 hash hex digest of the all fields in the initial requests (including signatures) 
+            SHA256 hash hex digest of all fields in the initial requests (including signatures) 
             
         - `payloadDigest` (SHA256 hex digest string):
             SHA256 hash hex digest of the payload fields in the initial requests, that is all fields excluding signatures and plugins-added ones
@@ -1390,6 +1390,7 @@ ConstraintEntity
 ```
 {
     'operation': {
+        'type':'120',
         'auth_type': '0', 
         'auth_action': 'EDIT',
         'field' :'services',
@@ -2342,28 +2343,28 @@ Each output list element is equal to the input of [AUTH_RULE](#auth_rule), so li
          'identifier':'M9BJDuS24bqbJNvBRsoGg3',
          
          'data':[  
-          {
-            'auth_type': '0', 
-            'auth_action': 'EDIT',
-            'field' :'services',
-            'old_value': [VALIDATOR],
-            'new_value': []
-            'constraint':{
-                  'constraint_id': 'OR',
-                  'auth_constraints': [{'constraint_id': 'ROLE', 
-                                        'role': '0',
-                                        'sig_count': 2, 
-                                        'need_to_be_owner': False, 
-                                        'metadata': {}}, 
-                                       
-                                       {'constraint_id': 'ROLE', 
-                                        'role': '2',
-                                        'sig_count': 1, 
-                                        'need_to_be_owner': True, 
-                                        'metadata': {}}
-                                       ]
-            }, 
-          }
+              {
+                'auth_type': '0', 
+                'auth_action': 'EDIT',
+                'field' :'services',
+                'old_value': [VALIDATOR],
+                'new_value': []
+                'constraint':{
+                      'constraint_id': 'OR',
+                      'auth_constraints': [{'constraint_id': 'ROLE', 
+                                            'role': '0',
+                                            'sig_count': 2, 
+                                            'need_to_be_owner': False, 
+                                            'metadata': {}}, 
+                                           
+                                           {'constraint_id': 'ROLE', 
+                                            'role': '2',
+                                            'sig_count': 1, 
+                                            'need_to_be_owner': True, 
+                                            'metadata': {}}
+                                           ]
+                }, 
+              }
          ],
 
          'state_proof':{  
@@ -2413,42 +2414,42 @@ Each output list element is equal to the input of [AUTH_RULE](#auth_rule), so li
          'identifier':'M9BJDuS24bqbJNvBRsoGg3'
 
          'data':[  
-          {
-            'auth_type': '0', 
-            'auth_action': 'EDIT',
-            'field' :'services',
-            'old_value': [VALIDATOR],
-            'new_value': []
-            'constraint':{
-                  'constraint_id': 'OR',
-                  'auth_constraints': [{'constraint_id': 'ROLE', 
-                                        'role': '0',
-                                        'sig_count': 2, 
-                                        'need_to_be_owner': False, 
-                                        'metadata': {}}, 
-                                       
-                                       {'constraint_id': 'ROLE', 
-                                        'role': '2',
-                                        'sig_count': 1, 
-                                        'need_to_be_owner': True, 
-                                        'metadata': {}}
-                                       ]
-            }, 
-          },
-          {
-            'auth_type': '102', 
-            'auth_action': 'ADD',
-            'field' :'*',
-            'new_value': '*'
-            'constraint':{
-                'constraint_id': 'ROLE', 
-                'role': '2',
-                'sig_count': 1, 
-                'need_to_be_owner': False, 
-                'metadata': {}
-            }, 
-          },
-          ........
+              {
+                'auth_type': '0', 
+                'auth_action': 'EDIT',
+                'field' :'services',
+                'old_value': [VALIDATOR],
+                'new_value': []
+                'constraint':{
+                      'constraint_id': 'OR',
+                      'auth_constraints': [{'constraint_id': 'ROLE', 
+                                            'role': '0',
+                                            'sig_count': 2, 
+                                            'need_to_be_owner': False, 
+                                            'metadata': {}}, 
+                                           
+                                           {'constraint_id': 'ROLE', 
+                                            'role': '2',
+                                            'sig_count': 1, 
+                                            'need_to_be_owner': True, 
+                                            'metadata': {}}
+                                           ]
+                }, 
+              },
+              {
+                'auth_type': '102', 
+                'auth_action': 'ADD',
+                'field' :'*',
+                'new_value': '*'
+                'constraint':{
+                    'constraint_id': 'ROLE', 
+                    'role': '2',
+                    'sig_count': 1, 
+                    'need_to_be_owner': False, 
+                    'metadata': {}
+                }, 
+              },
+              ........
          ],
 
       }

--- a/docs/source/requests.md
+++ b/docs/source/requests.md
@@ -1946,9 +1946,333 @@ Gets Claim Definition.
 
 ### GET_REVOC_REG_DEF
 
+Gets a Revocation Registry Definition, that Issuer creates and publishes for a particular Claim Definition.
+
+- `id` (string): Revocation Registry Definition's unique identifier (a key from state trie is currently used)
+
+*Request Example*:
+```
+{
+    'operation': {
+        'type': '115'
+        'id': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+    },
+    
+    'identifier': 'T6AD5g65TDQr1PPHHRoiGf',
+    'reqId': 1514308188474704,
+    'protocolVersion': 2
+}
+```
+
+*Reply Example*:
+```
+{
+    'op': 'REPLY', 
+    'result': {
+        'type': '115',
+        'identifier': 'T6AD5g65TDQr1PPHHRoiGf',
+        'reqId': 1514308188474704,
+        
+        'id': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+        
+        'seqNo': 10,
+        'txnTime': 1514214795,
+        
+        'data': {
+            'id': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+            'credDefId': 'FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag'
+            'revocDefType': 'CL_ACCUM',
+            'tag': 'tag1',
+            'value': {
+                'maxCredNum': 1000000,
+                'tailsHash': '6619ad3cf7e02fc29931a5cdc7bb70ba4b9283bda3badae297',
+                'tailsLocation': 'http://tails.location.com',
+                'issuanceType': 'ISSUANCE_BY_DEFAULT',
+                'publicKeys': {},
+            },
+        },
+        
+
+        'state_proof': {
+            'root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH',
+            'proof_nodes': '+QHl+FGAgICg0he/hjc9t/tPFzmCrb2T+nHnN0cRwqPKqZEc3pw2iCaAoAsA80p3oFwfl4dDaKkNI8z8weRsSaS9Y8n3HoardRzxgICAgICAgICAgID4naAgwxDOAEoIq+wUHr5h9jjSAIPDjS7SEG1NvWJbToxVQbh6+Hi4dnsiaWRlbnRpZmllciI6Ikw1QUQ1ZzY1VERRcjFQUEhIUm9pR2YiLCJyb2xlIjpudWxsLCJzZXFObyI6MTAsInR4blRpbWUiOjE1MTQyMTQ3OTUsInZlcmtleSI6In42dWV3Um03MmRXN1pUWFdObUFkUjFtIn348YCAgKDKj6ZIi+Ob9HXBy/CULIerYmmnnK2A6hN1u4ofU2eihKBna5MOCHiaObMfghjsZ8KBSbC6EpTFruD02fuGKlF1q4CAgICgBk8Cpc14mIr78WguSeT7+/rLT8qykKxzI4IO5ZMQwSmAoLsEwI+BkQFBiPsN8F610IjAg3+MVMbBjzugJKDo4NhYoFJ0ln1wq3FTWO0iw1zoUcO3FPjSh5ytvf1jvSxxcmJxoF0Hy14HfsVll8qa9aQ8T740lPFLR431oSefGorqgM5ioK1TJOr6JuvtBNByVMRv+rjhklCp6nkleiyLIq8vZYRcgIA=', 
+            'multi_signature': {
+                'value': {
+                    'timestamp': 1514308168,
+                    'ledger_id': 1, 
+                    'txn_root_hash': '4Y2DpBPSsgwd5CVE8Z2zZZKS4M6n9AbisT3jYvCYyC2y',
+                    'pool_state_root_hash': '9fzzkqU25JbgxycNYwUqKmM3LT8KsvUFkSSowD4pHpoK',
+                    'state_root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH'
+                },
+                'signature': 'REbtR8NvQy3dDRZLoTtzjHNx9ar65ttzk4jMqikwQiL1sPcHK4JAqrqVmhRLtw6Ed3iKuP4v8tgjA2BEvoyLTX6vB6vN4CqtFLqJaPJqMNZvr9tA5Lm6ZHBeEsH1QQLBYnWSAtXt658PotLUEp38sNxRh21t1zavbYcyV8AmxuVTg3',
+                'participants': ['Delta', 'Gamma', 'Alpha']
+            }
+        },
+        
+
+    }
+}
+```
+
 ### GET_REVOC_REG
 
+Gets a Revocation Registry Accumulator.
+
+- `revocRegDefId` (string): The corresponding Revocation Registry Definition's unique identifier (a key from state trie is currently used)
+
+- `timestamp` (integer as POSIX timestamp):
+
+    The time (from the ledger point of view) for which we want to get the accumulator value.
+
+*Request Example*:
+```
+{
+    'operation': {
+        'type': '116'
+        'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+        'timestamp': 1514214800
+    },
+    
+    'identifier': 'T6AD5g65TDQr1PPHHRoiGf',
+    'reqId': 1514308188474704,
+    'protocolVersion': 2
+}
+```
+
+*Reply Example*:
+```
+{
+    'op': 'REPLY', 
+    'result': {
+        'type': '116',
+        'identifier': 'T6AD5g65TDQr1PPHHRoiGf',
+        'reqId': 1514308188474704,
+        
+        'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+        'timestamp': 1514214800
+        
+        'seqNo': 10,
+        'txnTime': 1514214795,
+        
+        'data': {
+            'id': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+            'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1'
+            'revocDefType': 'CL_ACCUM',
+            'value': {
+                'accum': 'accum_value',
+            },
+        },
+        
+
+        'state_proof': {
+            'root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH',
+            'proof_nodes': '+QHl+FGAgICg0he/hjc9t/tPFzmCrb2T+nHnN0cRwqPKqZEc3pw2iCaAoAsA80p3oFwfl4dDaKkNI8z8weRsSaS9Y8n3HoardRzxgICAgICAgICAgID4naAgwxDOAEoIq+wUHr5h9jjSAIPDjS7SEG1NvWJbToxVQbh6+Hi4dnsiaWRlbnRpZmllciI6Ikw1QUQ1ZzY1VERRcjFQUEhIUm9pR2YiLCJyb2xlIjpudWxsLCJzZXFObyI6MTAsInR4blRpbWUiOjE1MTQyMTQ3OTUsInZlcmtleSI6In42dWV3Um03MmRXN1pUWFdObUFkUjFtIn348YCAgKDKj6ZIi+Ob9HXBy/CULIerYmmnnK2A6hN1u4ofU2eihKBna5MOCHiaObMfghjsZ8KBSbC6EpTFruD02fuGKlF1q4CAgICgBk8Cpc14mIr78WguSeT7+/rLT8qykKxzI4IO5ZMQwSmAoLsEwI+BkQFBiPsN8F610IjAg3+MVMbBjzugJKDo4NhYoFJ0ln1wq3FTWO0iw1zoUcO3FPjSh5ytvf1jvSxxcmJxoF0Hy14HfsVll8qa9aQ8T740lPFLR431oSefGorqgM5ioK1TJOr6JuvtBNByVMRv+rjhklCp6nkleiyLIq8vZYRcgIA=', 
+            'multi_signature': {
+                'value': {
+                    'timestamp': 1514308168,
+                    'ledger_id': 1, 
+                    'txn_root_hash': '4Y2DpBPSsgwd5CVE8Z2zZZKS4M6n9AbisT3jYvCYyC2y',
+                    'pool_state_root_hash': '9fzzkqU25JbgxycNYwUqKmM3LT8KsvUFkSSowD4pHpoK',
+                    'state_root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH'
+                },
+                'signature': 'REbtR8NvQy3dDRZLoTtzjHNx9ar65ttzk4jMqikwQiL1sPcHK4JAqrqVmhRLtw6Ed3iKuP4v8tgjA2BEvoyLTX6vB6vN4CqtFLqJaPJqMNZvr9tA5Lm6ZHBeEsH1QQLBYnWSAtXt658PotLUEp38sNxRh21t1zavbYcyV8AmxuVTg3',
+                'participants': ['Delta', 'Gamma', 'Alpha']
+            }
+        },
+        
+
+    }
+}
+```
+
 ### GET_REVOC_REG_DELTA
+
+Gets a Revocation Registry Delta (accum values, and delta of issues/revoked indices) for the given time interval (`from` and `to`).
+
+If from is not set, then the whole registry (accum and current issues/revoked indices) is returned for the given time (`to`)
+
+- `revocRegDefId` (string): The corresponding Revocation Registry Definition's unique identifier (a key from state trie is currently used)
+
+- `from` (integer as POSIX timestamp, optional):
+
+    The time (from the ledger point of view) we want to return accum and indices after, that is the left bound of the delta interval. Can be absent, which means that all indices and accum needs to be returned till `to`.
+
+- `to` (integer as POSIX timestamp):
+
+    The time (from the ledger point of view) we want to return accum and indices before, that is the right bound of the delta interval. 
+
+
+Please note, that if `from` is set, then addition state proof for `accum_from` value is returned in `stateProofFrom`, while the common state proof is for `accum_to`
+Both state proofs are returned just for accumulator values. The client needs to check that the returned delta is also correct by calculating `accum_to` from the given `accum_from` and delta indices, and making sure that the calculated  `accum_to` is equal to the returned one.
+
+If `from` is not set, then there is just one state proof (as usual) for both `accum` value and the whole indices lists. 
+
+*Request Example when both `from` and `to` present*:
+```
+{
+    'operation': {
+        'type': '117'
+        'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+        'from': 1514214100
+        'to': 1514214900
+    },
+    
+    'identifier': 'T6AD5g65TDQr1PPHHRoiGf',
+    'reqId': 1514308188474704,
+    'protocolVersion': 2
+}
+```
+
+*Reply Example when both `from` and `to` present*:
+```
+{
+    'op': 'REPLY', 
+    'result': {
+        'type': '117',
+        'identifier': 'T6AD5g65TDQr1PPHHRoiGf',
+        'reqId': 1514308188474704,
+        
+        'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+        'from': 1514214100
+        'to': 1514214900
+        
+        'seqNo': 18,
+        'txnTime': 1514214795,
+        
+        'data': {
+            'revocDefType': 'CL_ACCUM',
+            'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+            'value': {
+               'accum_to': {
+                   'revocDefType': 'CL_ACCUM', 
+                   'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1', 
+                   'txnTime': 1514214795, 
+                   'seqNo': 18,
+                   'value': {
+                      'accum': '9a512a7624'
+                   }
+                },
+                'revoked': [10, 11],
+                'issued': [1, 2, 3], 
+                'accum_from': {
+                    'revocDefType': 'CL_ACCUM',
+                    'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1', 
+                    'txnTime': 1514214105, 
+                    'seqNo': 16, 
+                    'value': {
+                       'accum': 'be080bd74b'
+                    }
+                 }
+            },
+            'stateProofFrom': {
+                'multi_signature': {
+                     'participants': ['Delta', 'Gamma', 'Alpha'],
+                     'signature': 'QpP4oVm2MLQ7SzLVZknuFjneXfqYj6UStn3oQtCdSiKiYuS4n1kxRphKRDMwmS7LGeXgUmy3C8GtcVM5X9SN9qLr2MBApjpPtKE9DkBTwyieh3vN1UMq1Kwx2Jkz7vcSJNH2WzjEKSUnpFLEJk4mpFaibqd1xX2hrwruxzSDUi2uCT', 
+                     'value': {
+                         'state_root_hash': '2sfnQcEKkjw78KYnGJyk5Gw9gtwESvX6NdFFPEiQYQsz', 
+                         'ledger_id': 1,
+                         'pool_state_root_hash': 'JDt3NNrZenx3x41oxsvhWeuSFFerdyqEvQUWyGdHX7gx',
+                         'timestamp': 1514214105, 
+                         'txn_root_hash': 'FCkntnPqfaGx4fCX5tTdWeLr1mXdFuZnTNuEehiet32z'
+                     }
+                },
+                'root_hash': '2sfnQcEKkjw78KYnGJyk5Gw9gtwESvX6NdFFPEiQYQsz',
+                'proof_nodes': '+QLB+QE3uFEgOk1TaktUV2tQTHRZb1BFYVRGMVRVRGI6NDpNU2pLVFdrUEx0WW9QRWFURjFUVURiOjM6Q0w6MTM6c29tZV90YWc6Q0xfQUNDVU06YTk4ZWO44vjguN57ImxzbiI6MTYsImx1dCI6MTU1ODUyNDEzMSwidmFsIjp7InJldm9jRGVmVHlwZSI6IkNMX0FDQ1VNIiwicmV2b2NSZWdEZWZJZCI6Ik1TaktUV2tQTHRZb1BFYVRGMVRVRGI6NDpNU2pLVFdrUEx0WW9QRWFURjFUVURiOjM6Q0w6MTM6c29tZV90YWc6Q0xfQUNDVU06YTk4ZWMiLCJzZXFObyI6MTYsInR4blRpbWUiOjE1NTg1MjQxMzEsInZhbHVlIjp7ImFjY3VtIjoiYmUwODBiZDc0YiJ9fX34UYCAgICAoAgDh8v1CXNEJGFl302RO98x8R6Ozscy0ZFdRpiCobh3oCnaxHyPnZq6E+mbnfU6oC994Wv1nh7sf0pQOp5g93tbgICAgICAgICAgPkBMYCAgKBmZE7e2jSrhTw9usjxZcAb25uSisJV+TzkbXNUypyJvaA/KAFG4RQqB9dAGRfTgly2XjXvPCeVr7vBn6FSkN7sH4CAoBGxQDip9XfEC/CkgimSkkhCeMm9XnkxxwWiMJwzuhAjgKAmh0g8FUI60e7NBwTu7ukdfz6kaON6u9U87kTeTlPcXICgsk2X2G6MlVhEqMEzthWAT4ey6qRaKXpOuMZOA1kMODagQdHobiexMaAwqtI7P5bbfqNkQEoZD79m6z43DEGQGL6gXQfLXgd+xWWXypr1pDxPvjSU8UtHjfWhJ58aiuqAzmKgyee3YL7GFFd+5oxG9b/q4od/mRjFpLdXKR3YG2o/hAygRIVVdoVD0dpqktsN8kSc03UhYiI76nxdCejX+CV4OX6A'
+            }
+        },
+        
+
+        'state_proof': {
+            'root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH',
+            'proof_nodes': '+QHl+FGAgICg0he/hjc9t/tPFzmCrb2T+nHnN0cRwqPKqZEc3pw2iCaAoAsA80p3oFwfl4dDaKkNI8z8weRsSaS9Y8n3HoardRzxgICAgICAgICAgID4naAgwxDOAEoIq+wUHr5h9jjSAIPDjS7SEG1NvWJbToxVQbh6+Hi4dnsiaWRlbnRpZmllciI6Ikw1QUQ1ZzY1VERRcjFQUEhIUm9pR2YiLCJyb2xlIjpudWxsLCJzZXFObyI6MTAsInR4blRpbWUiOjE1MTQyMTQ3OTUsInZlcmtleSI6In42dWV3Um03MmRXN1pUWFdObUFkUjFtIn348YCAgKDKj6ZIi+Ob9HXBy/CULIerYmmnnK2A6hN1u4ofU2eihKBna5MOCHiaObMfghjsZ8KBSbC6EpTFruD02fuGKlF1q4CAgICgBk8Cpc14mIr78WguSeT7+/rLT8qykKxzI4IO5ZMQwSmAoLsEwI+BkQFBiPsN8F610IjAg3+MVMbBjzugJKDo4NhYoFJ0ln1wq3FTWO0iw1zoUcO3FPjSh5ytvf1jvSxxcmJxoF0Hy14HfsVll8qa9aQ8T740lPFLR431oSefGorqgM5ioK1TJOr6JuvtBNByVMRv+rjhklCp6nkleiyLIq8vZYRcgIA=', 
+            'multi_signature': {
+                'value': {
+                    'timestamp': 1514308168,
+                    'ledger_id': 1, 
+                    'txn_root_hash': '4Y2DpBPSsgwd5CVE8Z2zZZKS4M6n9AbisT3jYvCYyC2y',
+                    'pool_state_root_hash': '9fzzkqU25JbgxycNYwUqKmM3LT8KsvUFkSSowD4pHpoK',
+                    'state_root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH'
+                },
+                'signature': 'REbtR8NvQy3dDRZLoTtzjHNx9ar65ttzk4jMqikwQiL1sPcHK4JAqrqVmhRLtw6Ed3iKuP4v8tgjA2BEvoyLTX6vB6vN4CqtFLqJaPJqMNZvr9tA5Lm6ZHBeEsH1QQLBYnWSAtXt658PotLUEp38sNxRh21t1zavbYcyV8AmxuVTg3',
+                'participants': ['Delta', 'Gamma', 'Alpha']
+            }
+        },
+        
+
+    }
+}
+```
+
+
+
+*Request Example when there is only `to` present*:
+```
+{
+    'operation': {
+        'type': '117'
+        'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+        'to': 1514214900
+    },
+    
+    'identifier': 'T6AD5g65TDQr1PPHHRoiGf',
+    'reqId': 1514308188474704,
+    'protocolVersion': 2
+}
+```
+
+*Reply Example when there is only `to` present*:
+```
+{
+    'op': 'REPLY', 
+    'result': {
+        'type': '117',
+        'identifier': 'T6AD5g65TDQr1PPHHRoiGf',
+        'reqId': 1514308188474704,
+        
+        'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+        'to': 1514214900
+        
+        'seqNo': 18,
+        'txnTime': 1514214795,
+        
+        'data': {
+            'revocDefType': 'CL_ACCUM',
+            'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+            'value': {
+               'accum_to': {
+                   'revocDefType': 'CL_ACCUM', 
+                   'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1', 
+                   'txnTime': 1514214795, 
+                   'seqNo': 18,
+                   'value': {
+                      'accum': '9a512a7624'
+                   }
+                },
+                'issued': [],
+                'revoked': [1, 2, 3, 4, 5]
+        },
+        
+
+        'state_proof': {
+            'root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH',
+            'proof_nodes': '+QHl+FGAgICg0he/hjc9t/tPFzmCrb2T+nHnN0cRwqPKqZEc3pw2iCaAoAsA80p3oFwfl4dDaKkNI8z8weRsSaS9Y8n3HoardRzxgICAgICAgICAgID4naAgwxDOAEoIq+wUHr5h9jjSAIPDjS7SEG1NvWJbToxVQbh6+Hi4dnsiaWRlbnRpZmllciI6Ikw1QUQ1ZzY1VERRcjFQUEhIUm9pR2YiLCJyb2xlIjpudWxsLCJzZXFObyI6MTAsInR4blRpbWUiOjE1MTQyMTQ3OTUsInZlcmtleSI6In42dWV3Um03MmRXN1pUWFdObUFkUjFtIn348YCAgKDKj6ZIi+Ob9HXBy/CULIerYmmnnK2A6hN1u4ofU2eihKBna5MOCHiaObMfghjsZ8KBSbC6EpTFruD02fuGKlF1q4CAgICgBk8Cpc14mIr78WguSeT7+/rLT8qykKxzI4IO5ZMQwSmAoLsEwI+BkQFBiPsN8F610IjAg3+MVMbBjzugJKDo4NhYoFJ0ln1wq3FTWO0iw1zoUcO3FPjSh5ytvf1jvSxxcmJxoF0Hy14HfsVll8qa9aQ8T740lPFLR431oSefGorqgM5ioK1TJOr6JuvtBNByVMRv+rjhklCp6nkleiyLIq8vZYRcgIA=', 
+            'multi_signature': {
+                'value': {
+                    'timestamp': 1514308168,
+                    'ledger_id': 1, 
+                    'txn_root_hash': '4Y2DpBPSsgwd5CVE8Z2zZZKS4M6n9AbisT3jYvCYyC2y',
+                    'pool_state_root_hash': '9fzzkqU25JbgxycNYwUqKmM3LT8KsvUFkSSowD4pHpoK',
+                    'state_root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH'
+                },
+                'signature': 'REbtR8NvQy3dDRZLoTtzjHNx9ar65ttzk4jMqikwQiL1sPcHK4JAqrqVmhRLtw6Ed3iKuP4v8tgjA2BEvoyLTX6vB6vN4CqtFLqJaPJqMNZvr9tA5Lm6ZHBeEsH1QQLBYnWSAtXt658PotLUEp38sNxRh21t1zavbYcyV8AmxuVTg3',
+                'participants': ['Delta', 'Gamma', 'Alpha']
+            }
+        },
+        
+
+    }
+}
+```
 
 ### GET_AUTH_RULE
 
@@ -2194,7 +2518,7 @@ All input parameters are optional and mutually exclusive.
             'multi_signature': {
                 'value': {
                     'timestamp': 1514308168,
-                    'ledger_id': 1, 
+                    'ledger_id': 2, 
                     'txn_root_hash': '4Y2DpBPSsgwd5CVE8Z2zZZKS4M6n9AbisT3jYvCYyC2y',
                     'pool_state_root_hash': '9fzzkqU25JbgxycNYwUqKmM3LT8KsvUFkSSowD4pHpoK',
                     'state_root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH'
@@ -2274,7 +2598,7 @@ All input parameters are optional and mutually exclusive.
             'multi_signature': {
                 'value': {
                     'timestamp': 1514308168,
-                    'ledger_id': 1, 
+                    'ledger_id': 2, 
                     'txn_root_hash': '4Y2DpBPSsgwd5CVE8Z2zZZKS4M6n9AbisT3jYvCYyC2y',
                     'pool_state_root_hash': '9fzzkqU25JbgxycNYwUqKmM3LT8KsvUFkSSowD4pHpoK',
                     'state_root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH'

--- a/docs/source/requests.md
+++ b/docs/source/requests.md
@@ -169,7 +169,7 @@ Additional (optional) fields for write requests:
 - `taaAcceptance` (dict, optional):
             If transaction author agreement is set/enabled, then every transaction (write request) from Domain and plugins-added ledgers must include acceptance of the latest transaction author agreement.
             
-   - `taaDigest` (SHA256 hex digest string): SHA256 hex digest of the latest Transaction Author Agreement on the ledger
+   - `taaDigest` (SHA256 hex digest string): SHA256 hex digest of the latest Transaction Author Agreement on the ledger. The digest is calculated from concatenation of [TRANSACTION_AUTHOR_AGREEMENT](#transaction_author_agreement)'s `version` and `text`.
                 
    - `mechanism` (string): a mechanism used to accept the signature; must be present in the latest list of transaction author agreement acceptane mechanisms on the ledger  
                 
@@ -2448,7 +2448,7 @@ Each output list element is equal to the input of [AUTH_RULE](#auth_rule), so li
 Gets a transaction author agreement.
 
 - Gets the latest (current) transaction author agreement if no input parameter is set.
-- Gets a transaction author agreement by its digest if `digest` is set.
+- Gets a transaction author agreement by its digest if `digest` is set. The digest is calculated from concatenation of [TRANSACTION_AUTHOR_AGREEMENT](#transaction_author_agreement)'s `version` and `text`.
 - Gets a transaction author agreement by its version if `version` is set.
 - Gets the latest (current) transaction author agreement at the given time (from ledger point of view) if `timestamp` is set.
 
@@ -2456,11 +2456,11 @@ All input parameters are optional and mutually exclusive.
 
 - `digest` (sha256 digest hex string):
 
-    Transaction's author agreement sha256 hash digest hex string
+    Transaction's author agreement sha256 hash digest hex string calculated from concatenation of [TRANSACTION_AUTHOR_AGREEMENT](#transaction_author_agreement)'s `version` and `text`.
     
 - `version` (string):
 
-    Unique version of the transaction author agreement
+    Unique version of the transaction author agreement.
     
 - `timestamp` (integer as POSIX timestamp):
 

--- a/docs/source/requests.md
+++ b/docs/source/requests.md
@@ -1279,9 +1279,9 @@ There are two types of constraints:
 - ConstraintList with format `{constraint_id, auth_constraints}` contains list of constraints.
 That is, the entry 
 ```
-'field' :'services',
 'auth_type': '0', 
 'auth_action': 'EDIT',
+'field' :'services',
 'old_value': [VALIDATOR],
 'new_value': []
 'constraint':{
@@ -1302,7 +1302,9 @@ That is, the entry
 
                                                                 
 ```
-means that changing a value of a NODE transaction's `service` field from `[VALIDATOR]` to `[]` (demotion of a node) can only be done by one TRUSTEE or one STEWARD, and this Trustee or Steward needs to be the owner (the original creator) of this transaction.
+means that changing a value of a NODE transaction's `service` field from `[VALIDATOR]` to `[]` (demotion of a node) can only be done by two TRUSTEEs or one STEWARD who is the owner (the original creator) of this transaction.
+
+Please note, that list elements of `GET_AUTH_RULE` output can be used as an input (with a required changes) for `AUTH_RULE`.
 
 **Action Format:**
 
@@ -1388,27 +1390,26 @@ ConstraintEntity
 ```
 {
     'operation': {
-           'type':'120',
-           'constraint':{  
-                      'constraint_id': 'OR',
-                      'auth_constraints': [{'constraint_id': 'ROLE', 
-                                            'role': '0',
-                                            'sig_count': 1, 
-                                            'need_to_be_owner': False, 
-                                            'metadata': {}}, 
-                                           
-                                           {'constraint_id': 'ROLE', 
-                                            'role': '2',
-                                            'sig_count': 1, 
-                                            'need_to_be_owner': True, 
-                                            'metadata': {}}
-                                           ]
-           }, 
-           'field' :'services',
-           'auth_type': '0', 
-           'auth_action': 'EDIT',
-           'old_value': [VALIDATOR],
-           'new_value': []
+        'auth_type': '0', 
+        'auth_action': 'EDIT',
+        'field' :'services',
+        'old_value': [VALIDATOR],
+        'new_value': []
+        'constraint':{
+              'constraint_id': 'OR',
+              'auth_constraints': [{'constraint_id': 'ROLE', 
+                                    'role': '0',
+                                    'sig_count': 2, 
+                                    'need_to_be_owner': False, 
+                                    'metadata': {}}, 
+                                   
+                                   {'constraint_id': 'ROLE', 
+                                    'role': '2',
+                                    'sig_count': 1, 
+                                    'need_to_be_owner': True, 
+                                    'metadata': {}}
+                                   ]
+        }, 
     },
     
     'identifier': '21BPzYYrFzbuECcBV3M1FH',
@@ -1437,11 +1438,16 @@ ConstraintEntity
          },
          'txn':{  
             'data':{  
-               'constraint':{  
+                'auth_type': '0', 
+                'auth_action': 'EDIT',
+                'field' :'services',
+                'old_value': [VALIDATOR],
+                'new_value': []            
+                'constraint':{  
                           'constraint_id': 'OR',
                           'auth_constraints': [{'constraint_id': 'ROLE', 
                                                 'role': '0',
-                                                'sig_count': 1, 
+                                                'sig_count': 2, 
                                                 'need_to_be_owner': False, 
                                                 'metadata': {}}, 
                                                
@@ -1451,13 +1457,7 @@ ConstraintEntity
                                                 'need_to_be_owner': True, 
                                                 'metadata': {}}
                                                ]
-               }, 
-               'field' :'services',
-               'auth_type': '0', 
-               'auth_action': 'EDIT',
-               'old_value': [VALIDATOR],
-               'new_value': []
-               }
+                }, 
             },
             'protocolVersion':2,
             'metadata':{  
@@ -1913,6 +1913,7 @@ Gets Claim Definition.
         'reqId': 1514308188474704,
         
         'seqNo': 10,
+        'txnTime': 1514214795,
 
         'state_proof': {
             'root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH',
@@ -1951,15 +1952,18 @@ Gets Claim Definition.
 
 ### GET_AUTH_RULE
 
-A request to get a constraint for an authentication rule or a full list of rules from Ledger by the auth key parameters.
-Two options are possible in a request build:
+A request to get an auth constraint for an authentication rule or a full list of rules from Ledger. The constraint format is described in [AUTH_RULE transaction](#auth_rule).
+
+The set of Auth Rules is static and can be found in [auth_rules.md](auth_rules.md). This is the constraint part that may be changed and edited. 
+
+Two options are possible in a request builder:
 - If the request has a full list of parameters (probably without `old_value` as it's not required for ADD actions), then the reply will contain one constraint for this key.
 - If the request does not contain fields other than txn_type, the response will contain a full list of authentication rules.
 
 A reply is a list of Auth Rules with constraints. This will be a one-element list in case of GET_AUTH_RULE with params, that is GET_AUTH_RULE for specific action.
 
-The set of Auth Rules is static and can be found in [auth_rules.md](auth_rules.md)). This is the constraint part that may be changed and edited. 
-The constraint format is described in [AUTH_RULE transaction](#auth_rule)
+Each output list element is equal to the input of [AUTH_RULE](#auth_rule), so list elements of `GET_AUTH_RULE` output can be used as an input (with a required changes) for `AUTH_RULE`.
+
 
 - `auth_action` (enum: `ADD` or `EDIT`; optional):
 
@@ -1988,11 +1992,11 @@ The constraint format is described in [AUTH_RULE transaction](#auth_rule)
       'signature':'366f89ehxLuxPySGcHppxbURWRcmXVdkHeHrjtPKNYSRKnvaxzUXF8CEUWy9KU251u5bmnRL3TKvQiZgjwouTJYH',
       'identifier':'M9BJDuS24bqbJNvBRsoGg3',
       'operation':{  
-         'field':'role',
-         'new_value':'101',
-         'type':'121',
-         'auth_type':'1',
-         'auth_action':'ADD'
+            'auth_type': '0', 
+            'auth_action': 'EDIT',
+            'field' :'services',
+            'old_value': [VALIDATOR],
+            'new_value': []
       },
       'protocolVersion':2
    }
@@ -2004,36 +2008,40 @@ The constraint format is described in [AUTH_RULE transaction](#auth_rule)
       'op':'REPLY',
       'result':{  
          'type':'121',
-         'auth_type':'1',
+         'auth_type': '0', 
+         'auth_action': 'EDIT',
+         'field' :'services',
+         'old_value': [VALIDATOR],
+         'new_value': []
+         
          'reqId':441933878,
          'identifier':'M9BJDuS24bqbJNvBRsoGg3',
-         'new_value':'101',
-         'data':{  
-            'ADD--1--role--*--101':{  
-               'auth_constraints':[  
-                  {  
-                     'sig_count':1,
-                     'role':'0',
-                     'constraint_id':'ROLE',
-                     'need_to_be_owner':False,
-                     'metadata':{  
+         
+         'data':[  
+          {
+            'auth_type': '0', 
+            'auth_action': 'EDIT',
+            'field' :'services',
+            'old_value': [VALIDATOR],
+            'new_value': []
+            'constraint':{
+                  'constraint_id': 'OR',
+                  'auth_constraints': [{'constraint_id': 'ROLE', 
+                                        'role': '0',
+                                        'sig_count': 2, 
+                                        'need_to_be_owner': False, 
+                                        'metadata': {}}, 
+                                       
+                                       {'constraint_id': 'ROLE', 
+                                        'role': '2',
+                                        'sig_count': 1, 
+                                        'need_to_be_owner': True, 
+                                        'metadata': {}}
+                                       ]
+            }, 
+          }
+         ],
 
-                     }
-                  },
-                  {  
-                     'sig_count':1,
-                     'role':'2',
-                     'constraint_id':'ROLE',
-                     'need_to_be_owner':False,
-                     'metadata':{  
-
-                     }
-                  }
-               ],
-               'constraint_id':'AND'
-            }
-         },
-         'field':'role',
          'state_proof':{  
             'proof_nodes':'+Pz4+pUgQURELS0xLS1yb2xlLS0qLS0xMDG44vjguN57ImF1dGhfY29uc3RyYWludHMiOlt7ImNvbnN0cmFpbnRfaWQiOiJST0xFIiwibWV0YWRhdGEiOnt9LCJuZWVkX3RvX2JlX293bmVyIjpmYWxzZSwicm9sZSI6IjAiLCJzaWdfY291bnQiOjF9LHsiY29uc3RyYWludF9pZCI6IlJPTEUiLCJtZXRhZGF0YSI6e30sIm5lZWRfdG9fYmVfb3duZXIiOmZhbHNlLCJyb2xlIjoiMiIsInNpZ19jb3VudCI6MX1dLCJjb25zdHJhaW50X2lkIjoiQU5EIn0=',
             'root_hash':'DauPq3KR6QFnkaAgcfgoMvvWR6UTdHKZgzbjepqWaBqF',
@@ -2053,7 +2061,6 @@ The constraint format is described in [AUTH_RULE transaction](#auth_rule)
                ]
             }
          },
-         'auth_action':'ADD'
       }
 }
 ```
@@ -2075,33 +2082,211 @@ The constraint format is described in [AUTH_RULE transaction](#auth_rule)
 ```
 {  
       'op':'REPLY',
-      'result':{  
-         'reqId':575407732,
+      'result':{
          'type':'121',
-         'data':{  
-            'ADD--118--action--*--*':{  
-               'constraint_id':'ROLE',
-               'sig_count':1,
-               'metadata':{  
-
-               },
-               'need_to_be_owner':False,
-               'role':'0'
-            },
-            'EDIT--1--role--0--':{  
-               'constraint_id':'ROLE',
-               'sig_count':1,
-               'metadata':{  
-
-               },
-               'need_to_be_owner':False,
-               'role':'0'
-            },
-            ...
-         },
+           
+         'reqId':575407732,
          'identifier':'M9BJDuS24bqbJNvBRsoGg3'
+
+         'data':[  
+          {
+            'auth_type': '0', 
+            'auth_action': 'EDIT',
+            'field' :'services',
+            'old_value': [VALIDATOR],
+            'new_value': []
+            'constraint':{
+                  'constraint_id': 'OR',
+                  'auth_constraints': [{'constraint_id': 'ROLE', 
+                                        'role': '0',
+                                        'sig_count': 2, 
+                                        'need_to_be_owner': False, 
+                                        'metadata': {}}, 
+                                       
+                                       {'constraint_id': 'ROLE', 
+                                        'role': '2',
+                                        'sig_count': 1, 
+                                        'need_to_be_owner': True, 
+                                        'metadata': {}}
+                                       ]
+            }, 
+          },
+          {
+            'auth_type': '102', 
+            'auth_action': 'ADD',
+            'field' :'*',
+            'new_value': '*'
+            'constraint':{
+                'constraint_id': 'ROLE', 
+                'role': '2',
+                'sig_count': 1, 
+                'need_to_be_owner': False, 
+                'metadata': {}
+            }, 
+          },
+          ........
+         ],
+
       }
    }
+```
+
+### GET_TRANSACTION_AUTHOR_AGREEMENT
+
+Gets a transaction author agreement.
+
+- Gets the latest (current) transaction author agreement if no input parameter is set.
+- Gets a transaction author agreement by its digest if `digest` is set.
+- Gets a transaction author agreement by its version if `version` is set.
+- Gets the latest (current) transaction author agreement at the given time (from ledger point of view) if `timestamp` is set.
+
+All input parameters are optional and mutually exclusive. 
+
+- `digest` (sha256 digest hex string):
+
+    Transaction's author agreement sha256 hash digest hex string
+    
+- `version` (string):
+
+    Unique version of the transaction author agreement
+    
+- `timestamp` (integer as POSIX timestamp):
+
+    The time when transaction author agreement has been ordered (written to the ledger).
+
+
+*Request Example*:
+```
+{
+    'operation': {
+        'type': '6'
+        'version': '1.0',
+    },
+    
+    'identifier': 'L5AD5g65TDQr1PPHHRoiGf',
+    'reqId': 1514308188474704,
+    'protocolVersion': 2
+}
+```
+
+*Reply Example*:
+```
+{
+    'op': 'REPLY', 
+    'result': {
+        'type': '6',
+        'identifier': 'L5AD5g65TDQr1PPHHRoiGf',
+        'reqId': 1514308188474704,
+        
+        'version': '1.0',
+        
+        'seqNo': 10,
+        'txnTime': 1514214795,
+
+        'data': {
+            "version": "1.0",
+            "text": "Please read carefully before writing anything to the ledger",
+        },
+
+        'state_proof': {
+            'root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH',
+            'proof_nodes': '+QHl+FGAgICg0he/hjc9t/tPFzmCrb2T+nHnN0cRwqPKqZEc3pw2iCaAoAsA80p3oFwfl4dDaKkNI8z8weRsSaS9Y8n3HoardRzxgICAgICAgICAgID4naAgwxDOAEoIq+wUHr5h9jjSAIPDjS7SEG1NvWJbToxVQbh6+Hi4dnsiaWRlbnRpZmllciI6Ikw1QUQ1ZzY1VERRcjFQUEhIUm9pR2YiLCJyb2xlIjpudWxsLCJzZXFObyI6MTAsInR4blRpbWUiOjE1MTQyMTQ3OTUsInZlcmtleSI6In42dWV3Um03MmRXN1pUWFdObUFkUjFtIn348YCAgKDKj6ZIi+Ob9HXBy/CULIerYmmnnK2A6hN1u4ofU2eihKBna5MOCHiaObMfghjsZ8KBSbC6EpTFruD02fuGKlF1q4CAgICgBk8Cpc14mIr78WguSeT7+/rLT8qykKxzI4IO5ZMQwSmAoLsEwI+BkQFBiPsN8F610IjAg3+MVMbBjzugJKDo4NhYoFJ0ln1wq3FTWO0iw1zoUcO3FPjSh5ytvf1jvSxxcmJxoF0Hy14HfsVll8qa9aQ8T740lPFLR431oSefGorqgM5ioK1TJOr6JuvtBNByVMRv+rjhklCp6nkleiyLIq8vZYRcgIA=', 
+            'multi_signature': {
+                'value': {
+                    'timestamp': 1514308168,
+                    'ledger_id': 1, 
+                    'txn_root_hash': '4Y2DpBPSsgwd5CVE8Z2zZZKS4M6n9AbisT3jYvCYyC2y',
+                    'pool_state_root_hash': '9fzzkqU25JbgxycNYwUqKmM3LT8KsvUFkSSowD4pHpoK',
+                    'state_root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH'
+                },
+                'signature': 'REbtR8NvQy3dDRZLoTtzjHNx9ar65ttzk4jMqikwQiL1sPcHK4JAqrqVmhRLtw6Ed3iKuP4v8tgjA2BEvoyLTX6vB6vN4CqtFLqJaPJqMNZvr9tA5Lm6ZHBeEsH1QQLBYnWSAtXt658PotLUEp38sNxRh21t1zavbYcyV8AmxuVTg3',
+                'participants': ['Delta', 'Gamma', 'Alpha']
+            }
+        },
+        
+       
+    }
+}
+```
+
+### GET_TRANSACTION_AUTHOR_AGREEMENT_AML
+
+Gets a transaction author agreement acceptance mechanisms list.
+
+- Gets the latest (current) transaction author agreement acceptance mechanisms list if no input parameter is set.
+- Gets a transaction author agreement acceptance mechanisms list by its version if `version` is set.
+- Gets the latest (current) transaction author agreement acceptance mechanisms list at the given time (from ledger point of view) if `timestamp` is set.
+
+All input parameters are optional and mutually exclusive. 
+
+   
+- `version` (string):
+
+    Unique version of the transaction author agreement acceptance mechanisms list
+    
+- `timestamp` (integer as POSIX timestamp):
+
+    The time when transaction author agreement acceptance mechanisms list has been ordered (written to the ledger).
+
+
+*Request Example*:
+```
+{
+    'operation': {
+        'type': '7'
+        'version': '1.0',
+    },
+    
+    'identifier': 'L5AD5g65TDQr1PPHHRoiGf',
+    'reqId': 1514308188474704,
+    'protocolVersion': 2
+}
+```
+
+*Reply Example*:
+```
+{
+    'op': 'REPLY', 
+    'result': {
+        'type': '7',
+        'identifier': 'L5AD5g65TDQr1PPHHRoiGf',
+        'reqId': 1514308188474704,
+        
+        'version': '1.0',
+        
+        'seqNo': 10,
+        'txnTime': 1514214795,
+
+        'data': {
+            "version": "1.0",
+            "aml": {
+                "EULA": "Included in the EULA for the product being used",
+                "Service Agreement": "Included in the agreement with the service provider managing the transaction",
+                "Click Agreement": "Agreed through the UI at the time of submission",
+                "Session Agreement": "Agreed at wallet instantiation or login"
+            },
+            "amlContext": "http://aml-context-descr"
+        },
+
+        'state_proof': {
+            'root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH',
+            'proof_nodes': '+QHl+FGAgICg0he/hjc9t/tPFzmCrb2T+nHnN0cRwqPKqZEc3pw2iCaAoAsA80p3oFwfl4dDaKkNI8z8weRsSaS9Y8n3HoardRzxgICAgICAgICAgID4naAgwxDOAEoIq+wUHr5h9jjSAIPDjS7SEG1NvWJbToxVQbh6+Hi4dnsiaWRlbnRpZmllciI6Ikw1QUQ1ZzY1VERRcjFQUEhIUm9pR2YiLCJyb2xlIjpudWxsLCJzZXFObyI6MTAsInR4blRpbWUiOjE1MTQyMTQ3OTUsInZlcmtleSI6In42dWV3Um03MmRXN1pUWFdObUFkUjFtIn348YCAgKDKj6ZIi+Ob9HXBy/CULIerYmmnnK2A6hN1u4ofU2eihKBna5MOCHiaObMfghjsZ8KBSbC6EpTFruD02fuGKlF1q4CAgICgBk8Cpc14mIr78WguSeT7+/rLT8qykKxzI4IO5ZMQwSmAoLsEwI+BkQFBiPsN8F610IjAg3+MVMbBjzugJKDo4NhYoFJ0ln1wq3FTWO0iw1zoUcO3FPjSh5ytvf1jvSxxcmJxoF0Hy14HfsVll8qa9aQ8T740lPFLR431oSefGorqgM5ioK1TJOr6JuvtBNByVMRv+rjhklCp6nkleiyLIq8vZYRcgIA=', 
+            'multi_signature': {
+                'value': {
+                    'timestamp': 1514308168,
+                    'ledger_id': 1, 
+                    'txn_root_hash': '4Y2DpBPSsgwd5CVE8Z2zZZKS4M6n9AbisT3jYvCYyC2y',
+                    'pool_state_root_hash': '9fzzkqU25JbgxycNYwUqKmM3LT8KsvUFkSSowD4pHpoK',
+                    'state_root_hash': '81bGgr7FDSsf4ymdqaWzfnN86TETmkUKH4dj4AqnokrH'
+                },
+                'signature': 'REbtR8NvQy3dDRZLoTtzjHNx9ar65ttzk4jMqikwQiL1sPcHK4JAqrqVmhRLtw6Ed3iKuP4v8tgjA2BEvoyLTX6vB6vN4CqtFLqJaPJqMNZvr9tA5Lm6ZHBeEsH1QQLBYnWSAtXt658PotLUEp38sNxRh21t1zavbYcyV8AmxuVTg3',
+                'participants': ['Delta', 'Gamma', 'Alpha']
+            }
+        },
+        
+       
+    }
+}
 ```
 
 ### GET_TXN

--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -922,7 +922,7 @@ That is, the entry
       'constraint_id': 'OR',
       'auth_constraints': [{'constraint_id': 'ROLE', 
                             'role': '0',
-                            'sig_count': 1, 
+                            'sig_count': 2, 
                             'need_to_be_owner': False, 
                             'metadata': {}}, 
                            
@@ -936,7 +936,7 @@ That is, the entry
 
                                                                 
 ```
-means that changing a value of a NODE transaction's `service` field from `[VALIDATOR]` to `[]` (demotion of a node) can only be done by one TRUSTEE or one STEWARD, and this Trustee or Steward needs to be the owner (the original creator) of this transaction.
+means that changing a value of a NODE transaction's `service` field from `[VALIDATOR]` to `[]` (demotion of a node) can only be done by two TRUSTEE or one STEWARD who is the owner (the original creator) of this transaction.
 
 **AbstractAuthConstraint:**
 
@@ -1003,19 +1003,26 @@ AuthConstraint
       'type':'120',
       'protocolVersion':2,
       'data':{  
-         'constraint':{  
-            'constraint_id':'ROLE',
-            'need_to_be_owner':False,
-            'role':'0',
-            'sig_count':1,
-            'metadata':{  
-
-            }
-         },
-         'auth_type':'1',
-         'new_value':'101',
-         'field':'role',
-         'auth_action':'ADD'
+        'auth_type': '0', 
+        'auth_action': 'EDIT',
+        'field' :'services',
+        'old_value': [VALIDATOR],
+        'new_value': []
+        'constraint':{
+              'constraint_id': 'OR',
+              'auth_constraints': [{'constraint_id': 'ROLE', 
+                                    'role': '0',
+                                    'sig_count': 2, 
+                                    'need_to_be_owner': False, 
+                                    'metadata': {}}, 
+                                   
+                                   {'constraint_id': 'ROLE', 
+                                    'role': '2',
+                                    'sig_count': 1, 
+                                    'need_to_be_owner': True, 
+                                    'metadata': {}}
+                                   ]
+        }, 
       },
       'metadata':{  
          'reqId':252174114,

--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -145,7 +145,7 @@ transaction specific data:
             Unique ID number of the request with transaction.
         
         - `digest` (SHA256 hex digest string):
-            SHA256 hash hex digest of the all fields in the initial requests (including signatures) 
+            SHA256 hash hex digest of all fields in the initial requests (including signatures) 
             
         - `payloadDigest` (SHA256 hex digest string):
             SHA256 hash hex digest of the payload fields in the initial requests, that is all fields excluding signatures and plugins-added ones

--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -110,14 +110,19 @@ transaction specific data:
 
         Supported transaction types:
 
-        - NODE = 0
-        - NYM = 1
-        - ATTRIB = 100
-        - SCHEMA = 101
-        - CLAIM_DEF = 102
-        - POOL_UPGRADE = 109
-        - NODE_UPGRADE = 110
-        - POOL_CONFIG = 111
+        - NODE = "0"
+        - NYM = "1"
+        - TXN_AUTHOR_AGREEMENT = "4"
+        - TXN_AUTHOR_AGREEMENT_AML = "5"
+        - ATTRIB = "100"
+        - SCHEMA = "101"
+        - CLAIM_DEF = "102"
+        - POOL_UPGRADE = "109"
+        - NODE_UPGRADE = "110"
+        - POOL_CONFIG = "111"
+        - REVOC_REG_DEF = "113"
+        - REVOC_REG_DEF = "114"
+        - AUTH_RULE = "120"
 
     - `protocolVersion` (integer; optional):
 
@@ -217,10 +222,11 @@ creation of new DIDs, setting and rotation of verification key, setting and chan
     Role of a user that the NYM record is being created for. One of the following values
 
     - None (common USER)
-    - 0 (TRUSTEE)
-    - 2 (STEWARD)
-    - 101 (TRUST_ANCHOR)
-
+    - "0" (TRUSTEE)
+    - "2" (STEWARD)
+    - "101" (TRUST_ANCHOR)
+    - "201" (NETWORK_MONITOR)
+    
   A TRUSTEE can change any Nym's role to None, thus stopping it from making any further writes (see [roles](auth_rules.md)).
 
 - `verkey` (base58-encoded string, possibly starting with "~"; optional):
@@ -908,95 +914,76 @@ There is a default Auth Constraint for every action (defined in [auth_rules.md](
 The `AUTH_RULE` command allows to change the Auth Constraint.
 So, it's not possible to register new actions by this command. But it's possible to override authentication constraints (values) for a given action.
 
-There are two types of constraints:
-- ConstraintEntity contains `{constraint_id, role, sig_count, need_to_be_owner, metadata}`
-- ConstraintList with format `{constraint_id, auth_constraints}` contains list of constraints.
-That is, the entry 
-```
-'field' :'services',
-'auth_type': '0', 
-'auth_action': 'EDIT',
-'old_value': [VALIDATOR],
-'new_value': []
-'constraint':{
-      'constraint_id': 'OR',
-      'auth_constraints': [{'constraint_id': 'ROLE', 
-                            'role': '0',
-                            'sig_count': 2, 
-                            'need_to_be_owner': False, 
-                            'metadata': {}}, 
-                           
-                           {'constraint_id': 'ROLE', 
-                            'role': '2',
-                            'sig_count': 1, 
-                            'need_to_be_owner': True, 
-                            'metadata': {}}
-                           ]
-}, 
+Please note, that list elements of `GET_AUTH_RULE` output can be used as an input (with a required changes) for `AUTH_RULE`.
 
-                                                                
-```
-means that changing a value of a NODE transaction's `service` field from `[VALIDATOR]` to `[]` (demotion of a node) can only be done by two TRUSTEE or one STEWARD who is the owner (the original creator) of this transaction.
+The following input parameters must match an auth rule from the [auth_rules.md](auth_rules.md):
+- `auth_type` (string enum)
+ 
+     The type of transaction to change the auth constraints to. (Example: "0", "1", ...). See transactions description to find the txn type enum value.
 
-**AbstractAuthConstraint:**
+- `auth_action` (enum: `ADD` or `EDIT`)
 
-AuthConstraintAnd, AuthConstraintOr
-
-- `constraint_id` (enum: `AND` or `OR`):
-
-    Type of a constraint class. It's needed to determine a type of constraint for correct deserialization.
-    - `AND` logical conjunction for all constraints from `auth_constraints` - AuthConstraintAnd
-    - `OR` logical disjunction for all constraints from `auth_constraints` - AuthConstraintOr
+    Whether this is addign of a new transaction, or editting of an existing one.
     
-- `auth_constraints` (list of ConstraintType):
-
-    List of ConstraintType (ConstraintList or ConstraintEntity) objects
+- `field` (string)
+ 
+    Set the auth constraint of editing the given specific field. `*` can be used to specify that an auth rule is applied to all fields.
     
- ```
-{ 'constraint_id': 'AND',
-  'auth_constraints': [<ConstraintEntity>,
-                      <ConstraintEntity>]
-}
-```
+- `old_value` (string; optional)
+
+    Old value of a field, which can be changed to a new_value. Must be present for EDIT `auth_action` only.
+    `*` can be used if it doesn't matter what was the old value.
     
-AuthConstraint
+- `new_value` (string)
 
-- `constraint_id` (enum: `ROLE`):
+    New value that can be used to fill the field.
+    `*` can be used if it doesn't matter what was the old value.
 
-      Type of a constraint. As of now only ROLE is supported, but plugins can register new ones. It's needed to determine a type of constraint for correct deserialization.
+The `constraint_id` fields is where one can define the desired auth constraint for the action:
+
+- `constraint` (dict)
+
+    - `constraint_id` (string enum)
+    
+        Constraint Type. As of now, the following constraint types are supported:
+            
+            - 'ROLE': a constraint defining how many siganatures of a given role are required
+            - 'OR': logical disjunction for all constraints from `auth_constraints` 
+            - 'AND': logical conjunction for all constraints from `auth_constraints`
+            
+    - fields if `'constraint_id': 'OR'` or `'constraint_id': 'AND'`
+    
+        - `auth_constraints` (list)
         
-- `role` (enum number as string; optional):
-
-    Role of a user that the NYM record is being created for. One of the following values
-
-    - None (common USER)
-    - 0 (TRUSTEE)
-    - 2 (STEWARD)
-    - 101 (TRUST_ANCHOR)
-   
-- `sig_count` (int):
-
-    The number of signatures that is needed to do the action described in the transaction fields.
+            A list of constraints. Any number of nested constraints is supported recursively
+        
+    - fields if `'constraint_id': 'ROLE'`:
+                
+        - `role` (string enum)    
+            
+            Who (what role) can perform the action
+            Please have a look at [NYM](#nym) transaction description for a mapping between role codes and names.
+                
+        - `sig_count` (int):
+        
+            The number of signatures that is needed to do the action
+            
+        - `need_to_be_owner` (boolean):
+        
+            Flag to check if the user must be the owner of a transaction (Example: A steward must be the owner of the node to make changes to it).
+            The notion of the `owner` is different for every auth rule. Please reference to [auth_rules.md](auth_rules.md) for details.
+            
+        - `metadata` (dict; optional):
+        
+            Dictionary for additional parameters of the constraint. Can be used by plugins to add additional restrictions.
     
-- `need_to_be_owner` (boolean):
 
-    Flag to check if the user must be owner of a transaction (Example: A steward must be the owner of the node to make changes to it).
-    
-- `metadata` (dict; optional):
-
-    Dictionary for additional parameters of the constraint. Can be used by plugins to add additional restrictions.
-
-```
-{
-    'sig_count': 1, 
-    'need_to_be_owner': False, 
-    'constraint_id': 'ROLE', 
-    'metadata': {}, 
-    'role': '0'
-}
-```
 
 **Example:**
+
+Let's consider an example of changing a value of a NODE transaction's `service` field from `[VALIDATOR]` to `[]` (demotion of a node).
+ We are going to set an Auth Constraint, so that the action can be only be done by two TRUSTEE or one STEWARD who is the owner (the original creator) of this transaction.
+
 ```
 {  
    'txn':{  

--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -158,11 +158,11 @@ transaction specific data:
         - `taaAcceptance` (dict, optional):
             If transaction author agreement is set/enabled, then every transaction (write request) from Domain and plugins-added ledgers must include acceptance of the latest transaction author agreement.
             
-                - `taaDigest` (SHA256 hex digest string): SHA256 hex digest of the latest Transaction Author Agreement on the ledger
-                
-                - `mechanism` (string): a mechanism used to accept the signature; must be present in the latest list of transaction author agreement acceptane mechanisms on the ledger  
-                
-                - `time` (integer as POSIX timestamp): transaction author agreement acceptance time
+            - `taaDigest` (SHA256 hex digest string): SHA256 hex digest of the latest Transaction Author Agreement on the ledger. The digest is calculated from concatenation of [TRANSACTION_AUTHOR_AGREEMENT](#transaction_author_agreement)'s `version` and `text`.
+            
+            - `mechanism` (string): a mechanism used to accept the signature; must be present in the latest list of transaction author agreement acceptane mechanisms on the ledger  
+            
+            - `time` (integer as POSIX timestamp): transaction author agreement acceptance time
                 
     - `txnMetadata` (dict):
 

--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -372,9 +372,6 @@ So, if the Schema needs to be evolved, a new Schema with a new version or new na
 #### CLAIM_DEF
 Adds a claim definition (in particular, public key), that Issuer creates and publishes for a particular claim schema.
 
-It's not possible to update `data` in an existing claim definition.
-Therefore if an existing claim definition needs to be evolved (for example, a key needs to be rotated), a new claim definition needs to be created for a new Issuer DID (`did`).
-
 - `data` (dict):
 
      Dictionary with claim definition's data:
@@ -437,6 +434,135 @@ Therefore if an existing claim definition needs to be evolved (for example, a ke
     }
 }
 ```
+
+#### REVOC_REG_DEF
+Adds a Revocation Registry Definition, that Issuer creates and publishes for a particular Claim Definition.
+It contains public keys, maximum number of credentials the registry may contain, reference to the Claim Def, plus some revocation registry specific data.
+
+- `value` (dict):
+
+     Dictionary with revocation registry definition's data:
+     
+     - `maxCredNum` (integer): a maximum number of credentials the Revocation Registry can handle
+     - `tailsHash` (string): tails' file digest
+     - `tailsLocation` (string): tails' file location (URL)
+     - `issuanceType` (string enum): defines credentials revocation strategy. Can have the following values:
+        - `ISSUANCE_BY_DEFAULT`: all credentials are assumed to be issued initially, so that Revocation Registry needs to be updated (REVOC_REG_ENTRY txn sent) only when revoking. Revocation Registry stores only revoked credentials indices in this case. Recommended to use if expected number of revocation actions is less than expected number of issuance actions. 
+        - `ISSUANCE_ON_DEMAND`: no credentials are issued initially, so that Revocation Registry needs to be updated (REVOC_REG_ENTRY txn sent) on every issuance and revocation. Revocation Registry stores only issued credentials indices in this case. Recommended to use if expected number of issuance actions is less than expected number of revocation actions.
+     - `publicKeys` (dict): Revocation Registry's public key
+
+- `id` (string): Revocation Registry Definition's unique identifier (a key from state trie is currently used)
+- `credDefId` (string): The corresponding Credential Definition's unique identifier (a key from state trie is currently used)
+- `revocDefType` (string enum): Revocation Type. `CL_ACCUM` (Camenisch-Lysyanskaya Accumulator) is the only supported type now.
+- `tag` (string): A unique tag to have multiple Revocation Registry Definitions for the same Credential Definition and type issued by the same DID. 
+
+**Example**:
+```
+{
+    "ver": 1,
+    "txn": {
+        "type":113,
+        "protocolVersion":1,
+
+        "data": {
+            "ver":1,
+            'id': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1',
+            'credDefId': 'FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag'
+            'revocDefType': 'CL_ACCUM',
+            'tag': 'tag1',
+            'value': {
+                'maxCredNum': 1000000,
+                'tailsHash': '6619ad3cf7e02fc29931a5cdc7bb70ba4b9283bda3badae297',
+                'tailsLocation': 'http://tails.location.com',
+                'issuanceType': 'ISSUANCE_BY_DEFAULT',
+                'publicKeys': {},
+            },
+        },
+
+        "metadata": {
+            "reqId":1513945121191691,
+            "from":"L5AD5g65TDQr1PPHHRoiGf",
+            'digest': '4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453',
+            'payloadDigest': '21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685'
+        },
+    },
+    "txnMetadata": {
+        "txnTime":1513945121,
+        "seqNo": 10,
+        "txnId":"L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1",
+    },
+    "reqSignature": {
+        "type": "ED25519",
+        "values": [{
+            "from": "L5AD5g65TDQr1PPHHRoiGf",
+            "value": "4X3skpoEK2DRgZxQ9PwuEvCJpL8JHdQ8X4HDDFyztgqE15DM2ZnkvrAh9bQY16egVinZTzwHqznmnkaFM4jjyDgd"
+        }]
+    }
+}
+```
+
+#### REVOC_REG_ENTRY
+Adds a Revocation Registry Definition (in particular, a public key), that Issuer creates and publishes for a particular Claim Definition.
+
+- `value` (dict):
+
+     Dictionary with revocation registry definition's data:
+     
+     - `maxCredNum` (integer): a maximum number of credentials the Revocation Registry can handle
+     - `tailsHash` (string): tails' file digest
+     - `tailsLocation` (string): tails' file location (URL)
+     - `issuanceType` (string enum): defines credentials revocation strategy. Can have the following values:
+        - `ISSUANCE_BY_DEFAULT`: all credentials are assumed to be issued initially, so that Revocation Registry needs to be updated (REVOC_REG_ENTRY txn sent) only when revoking. Revocation Registry stores only revoked credentials indices in this case. Recommended to use if expected number of revocation actions is less than expected number of issuance actions. 
+        - `ISSUANCE_ON_DEMAND`: no credentials are issued initially, so that Revocation Registry needs to be updated (REVOC_REG_ENTRY txn sent) on every issuance and revocation. Revocation Registry stores only issued credentials indices in this case. Recommended to use if expected number of issuance actions is less than expected number of revocation actions.
+     - `publicKeys` (dict): Revocation Registry's public key
+
+- `id` (string): Revocation Registry Definition's unique identifier (a key from state trie is currently used)
+- `credDefId` (string): The corresponding Credential Definition's unique identifier (a key from state trie is currently used)
+- `revocDefType` (string enum): Revocation Type. `CL_ACCUM` (Camenisch-Lysyanskaya Accumulator) is the only supported type now.
+- `tag` (string): A unique tag to have multiple Revocation Registry Definitions for the same Credential Definition and type issued by the same DID. 
+
+**Example**:
+```
+{
+    "ver": 1,
+    "txn": {
+        "type":114,
+        "protocolVersion":1,
+
+        "data": {
+            "ver":1,
+            'revocRegDefId': 'L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1'
+            'revocDefType': 'CL_ACCUM',
+            'value': {
+                'accum': 'accum_value',
+                'prevAccum': 'prev_acuum_value',
+                'issued': [],
+                'revoked': [10, 36, 3478],
+            },
+        },
+
+        "metadata": {
+            "reqId":1513945121191691,
+            "from":"L5AD5g65TDQr1PPHHRoiGf",
+            'digest': '4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453',
+            'payloadDigest': '21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685'
+        },
+    },
+    "txnMetadata": {
+        "txnTime":1513945121,
+        "seqNo": 10,
+        "txnId":"5:L5AD5g65TDQr1PPHHRoiGf:3:FC4aWomrA13YyvYC1Mxw7:3:CL:14:some_tag:CL_ACCUM:tag1",
+    },
+    "reqSignature": {
+        "type": "ED25519",
+        "values": [{
+            "from": "L5AD5g65TDQr1PPHHRoiGf",
+            "value": "4X3skpoEK2DRgZxQ9PwuEvCJpL8JHdQ8X4HDDFyztgqE15DM2ZnkvrAh9bQY16egVinZTzwHqznmnkaFM4jjyDgd"
+        }]
+    }
+}
+```
+
 
 ## Pool Ledger
 

--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -9,6 +9,8 @@
     * [ATTRIB](#attrib)
     * [SCHEMA](#schema)
     * [CLAIM_DEF](#claim_def)
+    * [REVOC_REG_DEF](#revoc_reg_def)
+    * [REVOC_REG_ENTRY](#revoc_reg_entry)
 
 * [Pool Ledger](#pool-ledger)
     * [NODE](#node)
@@ -18,6 +20,11 @@
     * [NODE_UPGRADE](#node_upgrade)
     * [POOL_CONFIG](#pool_config)
     * [AUTH_RULE](#auth_rule)
+    * [TRANSACTION_AUTHOR_AGREEMENT](#transaction_author_agreement)
+    * [TRANSACTION_AUTHOR_AGREEMENT_AML](#transaction_author_agreement_AML)    
+    
+* [Actions](#actions)
+    * [POOL_RESTART](#pool_restart)    
 
 ## General Information
 
@@ -66,7 +73,14 @@ transaction specific data:
 
         "metadata": {
             "reqId": <...>,
-            "from": <...>
+            "from": <...>,
+            "digest": <...>,
+            "payloadDigest": <...>,
+            "taaAcceptance": {
+                "taaDigest": <...>,
+                "mechanism": <...>,
+                "time": <...>
+             }
         },
     },
     "txnMetadata": {
@@ -129,7 +143,22 @@ transaction specific data:
 
         - `reqId` (integer):
             Unique ID number of the request with transaction.
-
+        
+        - `digest` (SHA256 hex digest string):
+            SHA256 hash hex digest of the all fields in the initial requests (including signatures) 
+            
+        - `payloadDigest` (SHA256 hex digest string):
+            SHA256 hash hex digest of the payload fields in the initial requests, that is all fields excluding signatures and plugins-added ones
+            
+        - `taaAcceptance` (dict, optional):
+            If transaction author agreement is set/enabled, then every transaction (write request) from Domain and plugins-added ledgers must include acceptance of the latest transaction author agreement.
+            
+                - `taaDigest` (SHA256 hex digest string): SHA256 hex digest of the latest Transaction Author Agreement on the ledger
+                
+                - `mechanism` (string): a mechanism used to accept the signature; must be present in the latest list of transaction author agreement acceptane mechanisms on the ledger  
+                
+                - `time` (integer as POSIX timestamp): transaction author agreement acceptance time
+                
     - `txnMetadata` (dict):
 
         Metadata attached to the transaction.
@@ -234,6 +263,13 @@ So, if key rotation needs to be performed, the owner of the DID needs to send a 
         "metadata": {
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest": "4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
+            "taaAcceptance": {
+                "taaDigest": "6sh15d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+                "mechanism": "EULA",
+                "time": 1513942017
+             }
         },
     },
     "txnMetadata": {
@@ -298,6 +334,13 @@ Adds an attribute to a NYM record
         "metadata": {
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest": "4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
+            "taaAcceptance": {
+                "taaDigest": "6sh15d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+                "mechanism": "EULA",
+                "time": 1513942017
+             }            
         },
     },
     "txnMetadata": {
@@ -351,6 +394,13 @@ So, if the Schema needs to be evolved, a new Schema with a new version or new na
         "metadata": {
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest": "4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
+            "taaAcceptance": {
+                "taaDigest": "6sh15d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+                "mechanism": "EULA",
+                "time": 1513942017
+             }            
         },
     },
     "txnMetadata": {
@@ -418,6 +468,13 @@ Adds a claim definition (in particular, public key), that Issuer creates and pub
         "metadata": {
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest": "4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
+            "taaAcceptance": {
+                "taaDigest": "6sh15d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+                "mechanism": "EULA",
+                "time": 1513942017
+             }                  
         },
     },
     "txnMetadata": {
@@ -483,7 +540,12 @@ It contains public keys, maximum number of credentials the registry may contain,
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
             'digest': '4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453',
-            'payloadDigest': '21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685'
+            'payloadDigest': '21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685',
+            "taaAcceptance": {
+                "taaDigest": "6sh15d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+                "mechanism": "EULA",
+                "time": 1513942017
+             }                  
         },
     },
     "txnMetadata": {
@@ -502,24 +564,20 @@ It contains public keys, maximum number of credentials the registry may contain,
 ```
 
 #### REVOC_REG_ENTRY
-Adds a Revocation Registry Definition (in particular, a public key), that Issuer creates and publishes for a particular Claim Definition.
+The RevocReg entry containing the new accumulator value and issued/revoked indices. This is just a delta of indices, not the whole list. So, it can be sent each time a new claim is issued/revoked.
 
 - `value` (dict):
 
-     Dictionary with revocation registry definition's data:
+     Dictionary with revocation registry's data:
      
-     - `maxCredNum` (integer): a maximum number of credentials the Revocation Registry can handle
-     - `tailsHash` (string): tails' file digest
-     - `tailsLocation` (string): tails' file location (URL)
-     - `issuanceType` (string enum): defines credentials revocation strategy. Can have the following values:
-        - `ISSUANCE_BY_DEFAULT`: all credentials are assumed to be issued initially, so that Revocation Registry needs to be updated (REVOC_REG_ENTRY txn sent) only when revoking. Revocation Registry stores only revoked credentials indices in this case. Recommended to use if expected number of revocation actions is less than expected number of issuance actions. 
-        - `ISSUANCE_ON_DEMAND`: no credentials are issued initially, so that Revocation Registry needs to be updated (REVOC_REG_ENTRY txn sent) on every issuance and revocation. Revocation Registry stores only issued credentials indices in this case. Recommended to use if expected number of issuance actions is less than expected number of revocation actions.
-     - `publicKeys` (dict): Revocation Registry's public key
+     - `accum` (string): the current accumulator value
+     - `prevAccum` (string): the previous accumulator value; it's compared with the current value, and txn is rejected if they don't match; it's needed to avoid dirty writes and updates of accumulator.
+     - `issued` (list of integers): an array of issued indices (may be absent/empty if the type is ISSUANCE_BY_DEFAULT); this is delta; will be accumulated in state.
+     - `revoked` (list of integers):  an array of revoked indices (delta; will be accumulated in state)    
 
-- `id` (string): Revocation Registry Definition's unique identifier (a key from state trie is currently used)
-- `credDefId` (string): The corresponding Credential Definition's unique identifier (a key from state trie is currently used)
+- `revocRegDefId` (string): The corresponding Revocation Registry Definition's unique identifier (a key from state trie is currently used)
 - `revocDefType` (string enum): Revocation Type. `CL_ACCUM` (Camenisch-Lysyanskaya Accumulator) is the only supported type now.
-- `tag` (string): A unique tag to have multiple Revocation Registry Definitions for the same Credential Definition and type issued by the same DID. 
+
 
 **Example**:
 ```
@@ -545,7 +603,12 @@ Adds a Revocation Registry Definition (in particular, a public key), that Issuer
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
             'digest': '4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453',
-            'payloadDigest': '21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685'
+            'payloadDigest': '21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685',
+            "taaAcceptance": {
+                "taaDigest": "6sh15d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+                "mechanism": "EULA",
+                "time": 1513942017
+             }                  
         },
     },
     "txnMetadata": {
@@ -621,12 +684,13 @@ There is no need to specify all other fields, and they will remain the same.
         "metadata": {
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest": "4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
         },
     },
     "txnMetadata": {
         "txnTime":1513945121,
         "seqNo": 10,
-        "txnId":"Delta",
     },
     "reqSignature": {
         "type": "ED25519",
@@ -714,7 +778,8 @@ Command to upgrade the Pool (sent by Trustee). It upgrades the specified Nodes (
         "metadata": {
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
-            "txnId":"upgrade-13",
+            "digest": "4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
         },
     },
     "txnMetadata": {
@@ -760,12 +825,13 @@ Status of each Node's upgrade (sent by each upgraded Node)
         "metadata": {
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest": "4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
         },
     },
     "txnMetadata": {
         "txnTime":1513945121,
         "seqNo": 10,
-        "txnId":"upgrade-13",
     },
     "reqSignature": {
         "type": "ED25519",
@@ -813,12 +879,13 @@ Command to change Pool's configuration
         "metadata": {
             "reqId":1513945121191691,
             "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest": "4ba05d9b2c27e52aa8778708fb4b3e5d7001eecd02784d8e311d27b9090d9453",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
         },
     },
     "txnMetadata": {
         "txnTime":1513945121,
         "seqNo": 10,
-        "txnId":"1111",
     },
     "reqSignature": {
         "type": "ED25519",
@@ -923,10 +990,6 @@ AuthConstraint
 **Example:**
 ```
 {  
-   'txnMetadata':{  
-      'txnTime':1551785798,
-      'seqNo':1
-   },
    'txn':{  
       'type':'120',
       'protocolVersion':2,
@@ -947,10 +1010,15 @@ AuthConstraint
       },
       'metadata':{  
          'reqId':252174114,
+         'from':'M9BJDuS24bqbJNvBRsoGg3',
          'digest':'6cee82226c6e276c983f46d03e3b3d10436d90b67bf33dc67ce9901b44dbc97c',
-         'from':'M9BJDuS24bqbJNvBRsoGg3'
+         'payloadDigest': '21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685',
       }
    },
+   'txnMetadata':{  
+      'txnTime':1551785798,
+      'seqNo':1
+   },   
    'reqSignature':{  
       'type':'ED25519',
       'values':[  
@@ -964,8 +1032,129 @@ AuthConstraint
 }
 ```
 
+#### TRANSACTION_AUTHOR_AGREEMENT
 
-## Action Transactions
+Setting (enabling/disabling) a transaction author agreement for the pool.
+If transaction author agreement is set, then all write requests to Domain ledger (transactions) must include additional metadata pointing to the latest transaction author agreement's digest which is signed by the transaction author.
+
+If no transaction author agreement is set, or it's disabled, then no additional metadata is required.
+
+Transaction author agreement can be disabled by setting an agreement with an empty text.
+
+Each transaction author agreement has a unique version.
+
+- `version` (string):
+
+    Unique version of the transaction author agreement
+
+
+- `text` (string):
+
+    Transaction author agreement's text
+
+**Example:**
+```
+{
+    "ver":1,
+    "txn": {
+        "type":4,
+        "protocolVersion":1,
+
+        "data": {
+            "ver":1,
+            "version": "1.0",
+            "text": "Please read carefully before writing anything to the ledger",
+        },
+
+        "metadata": {
+            "reqId":1513945121191691,
+            "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest":"6cee82226c6e276c983f46d03e3b3d10436d90b67bf33dc67ce9901b44dbc97c",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
+        },
+    },
+    "txnMetadata": {
+        "txnTime":1513945121,
+        "seqNo": 10,
+    },
+    "reqSignature": {
+        "type": "ED25519",
+        "values": [{
+            "from": "L5AD5g65TDQr1PPHHRoiGf",
+            "value": "4X3skpoEK2DRgZxQ9PwuEvCJpL8JHdQ8X4HDDFyztgqE15DM2ZnkvrAh9bQY16egVinZTzwHqznmnkaFM4jjyDgd"
+        }]
+    }
+}
+```
+
+#### TRANSACTION_AUTHOR_AGREEMENT_AML
+
+Setting a list of acceptance mechanisms for transaction author agreement.
+
+Each write request for which a transaction author agreement needs to be accepted must point to a  mechanism from the latest list on the ledger. The chosen mechanism is signed by the write request author (together with the transaction author agreement digest). 
+
+
+Each acceptance mechanisms list has a unique version.
+
+- `version` (string):
+
+    Unique version of the transaction author agreement acceptance mechanisms list
+
+
+- `aml` (dict):
+
+    Acceptance mechanisms list data in the form `<acceptance mechanism label>: <acceptance mechanism description>`
+    
+- `amlContext` (string, optional):
+
+    A context information about Acceptance mechanisms list (may be URL to external resource).   
+    
+    
+
+**Example:**
+```
+{
+    "ver":1,
+    "txn": {
+        "type":4,
+        "protocolVersion":1,
+
+        "data": {
+            "ver":1,
+            "version": "1.0",
+            "aml": {
+                "EULA": "Included in the EULA for the product being used",
+                "Service Agreement": "Included in the agreement with the service provider managing the transaction",
+                "Click Agreement": "Agreed through the UI at the time of submission",
+                "Session Agreement": "Agreed at wallet instantiation or login"
+            },
+            "amlContext": "http://aml-context-descr"
+        },
+
+        "metadata": {
+            "reqId":1513945121191691,
+            "from":"L5AD5g65TDQr1PPHHRoiGf",
+            "digest":"6cee82226c6e276c983f46d03e3b3d10436d90b67bf33dc67ce9901b44dbc97c",
+            "payloadDigest": "21f0f5c158ed6ad49ff855baf09a2ef9b4ed1a8015ac24bccc2e0106cd905685",
+        },
+    },
+    "txnMetadata": {
+        "txnTime":1513945121,
+        "seqNo": 10,
+    },
+    "reqSignature": {
+        "type": "ED25519",
+        "values": [{
+            "from": "L5AD5g65TDQr1PPHHRoiGf",
+            "value": "4X3skpoEK2DRgZxQ9PwuEvCJpL8JHdQ8X4HDDFyztgqE15DM2ZnkvrAh9bQY16egVinZTzwHqznmnkaFM4jjyDgd"
+        }]
+    }
+}
+```
+
+## Actions
+
+The actions are not written to the Ledger, so this is not a transaction, just a command.
 
 #### POOL_RESTART
 POOL_RESTART is the command to restart all nodes at the time specified in field "datetime"(sent by Trustee).

--- a/indy_common/authorize/auth_constraints.py
+++ b/indy_common/authorize/auth_constraints.py
@@ -83,24 +83,32 @@ class AuthConstraint(AbstractAuthConstraint):
             raise ValueError("Role {} is not acceptable".format(role))
 
     def __str__(self):
+        metadata_str = self._metadata_str()
         role = get_named_role(self.role) if self.role != '*' else 'ALL'
         if role != 'ALL' and self.need_to_be_owner and self.sig_count > 1:
-            return "{} {} signatures are required and needs to be owner".format(self.sig_count, role)
+            return "{} {} signatures {} are required and needs to be owner".format(self.sig_count, role, metadata_str)
         elif role != 'ALL' and not self.need_to_be_owner and self.sig_count > 1:
-            return "{} {} signatures are required".format(self.sig_count, role)
+            return "{} {} signatures {} are required".format(self.sig_count, role, metadata_str)
         elif role != 'ALL' and not self.need_to_be_owner and self.sig_count == 1:
-            return "1 {} signature is required".format(role)
+            return "1 {} signature {} is required".format(role, metadata_str)
         elif role != 'ALL' and self.need_to_be_owner and self.sig_count == 1:
-            return "1 {} signature is required and needs to be owner".format(role)
+            return "1 {} signature {} is required and needs to be owner".format(role, metadata_str)
 
         elif role == "ALL" and self.need_to_be_owner and self.sig_count == 1:
-            return "1 signature of any role is required and needs to be owner"
+            return "1 signature of any role {} is required and needs to be owner".format(metadata_str)
         elif role == 'ALL' and not self.need_to_be_owner and self.sig_count == 1:
-            return "1 signature of any role is required".format(role)
+            return "1 signature of any role {} is required".format(metadata_str)
         elif role == 'ALL' and not self.need_to_be_owner and self.sig_count > 1:
-            return "{} signatures of any role are required".format(self.sig_count)
+            return "{} signatures of any role {} are required".format(self.sig_count, metadata_str)
         elif role == "ALL" and self.need_to_be_owner and self.sig_count > 1:
-            return "{} signatures of any role are required and needs to be owner".format(self.sig_count)
+            return "{} signatures of any role {} are required and needs to be owner".format(self.sig_count,
+                                                                                            metadata_str)
+
+    def _metadata_str(self):
+        if not self.metadata:
+            return ""
+        res = " ".join([str(item) for values in self.metadata.items() for item in values])
+        return "with {}".format(res)
 
     @staticmethod
     def from_dict(as_dict):

--- a/indy_common/authorize/auth_constraints.py
+++ b/indy_common/authorize/auth_constraints.py
@@ -105,14 +105,14 @@ class AuthConstraint(AbstractAuthConstraint):
 
         metadata_str = self._metadata_str()
         if metadata_str:
-            return "{} with additional metadata: {}".format(error_msg, self.metadata)
+            return "{} {}".format(error_msg, metadata_str)
         return error_msg
 
     def _metadata_str(self):
         if not self.metadata:
             return ""
         res = " ".join([str(item) for values in self.metadata.items() for item in values])
-        return "with {}".format(res)
+        return "with additional metadata {}".format(res)
 
     @staticmethod
     def from_dict(as_dict):

--- a/indy_common/authorize/authorizer.py
+++ b/indy_common/authorize/authorizer.py
@@ -176,7 +176,8 @@ class OrAuthorizer(AbstractAuthorizer):
                 successes.append(True)
         if len(successes) == 0:
             raise AuthValidationError(
-                "Rule for this action is: {}{}Failed checks: {}".format(auth_constraint,
-                                                                        os.linesep,
-                                                                        os.linesep.join(fails)))
+                os.linesep.join(["Rule for this action is: {}".format(auth_constraint),
+                                 "Failed checks:",
+                                 os.linesep.join(fails)])
+            )
         return True, ""

--- a/indy_common/test/auth/metadata/test_error_messages.py
+++ b/indy_common/test/auth/metadata/test_error_messages.py
@@ -1,0 +1,65 @@
+import pytest
+
+from indy_common.authorize.auth_constraints import AuthConstraint, IDENTITY_OWNER, AuthConstraintOr
+from indy_common.test.auth.metadata.helper import set_auth_constraint, PLUGIN_FIELD, build_req_and_action
+from plenum.common.constants import TRUSTEE, STEWARD
+from plenum.common.exceptions import UnauthorizedClientRequest
+
+MAX_SIG_COUNT = 3
+
+
+def test_plugin_simple_error_msg_no_plugin_field(write_auth_req_validator):
+    set_auth_constraint(write_auth_req_validator,
+                        AuthConstraint(role=IDENTITY_OWNER, sig_count=1, need_to_be_owner=True,
+                                       metadata={PLUGIN_FIELD: 2}))
+    req, actions = build_req_and_action(signatures={IDENTITY_OWNER: 1},
+                                        need_to_be_owner=True,
+                                        amount=None)
+
+    with pytest.raises(UnauthorizedClientRequest) as excinfo:
+        write_auth_req_validator.validate(req, actions)
+    assert ("missing required plugin field") in str(excinfo.value)
+
+
+def test_plugin_simple_error_msg_extra_plugin_field(write_auth_req_validator):
+    set_auth_constraint(write_auth_req_validator,
+                        AuthConstraint(role=IDENTITY_OWNER, sig_count=1, need_to_be_owner=True))
+    req, actions = build_req_and_action(signatures={IDENTITY_OWNER: 1},
+                                        need_to_be_owner=True,
+                                        amount=5)
+
+    with pytest.raises(UnauthorizedClientRequest) as excinfo:
+        write_auth_req_validator.validate(req, actions)
+    assert ("plugin field must be absent") in str(excinfo.value)
+
+
+def test_plugin_simple_error_msg_not_enough_amount(write_auth_req_validator):
+    set_auth_constraint(write_auth_req_validator,
+                        AuthConstraint(role=IDENTITY_OWNER, sig_count=1, need_to_be_owner=True,
+                                       metadata={PLUGIN_FIELD: 10}))
+    req, actions = build_req_and_action(signatures={IDENTITY_OWNER: 1},
+                                        need_to_be_owner=True,
+                                        amount=5)
+
+    with pytest.raises(UnauthorizedClientRequest) as excinfo:
+        write_auth_req_validator.validate(req, actions)
+    assert ("not enough amount in plugin field") in str(excinfo.value)
+
+
+def test_plugin_or_error_msg_not_enough_amount(write_auth_req_validator):
+    set_auth_constraint(write_auth_req_validator,
+                        AuthConstraintOr(auth_constraints=[
+                            AuthConstraint(role=TRUSTEE, sig_count=1, need_to_be_owner=False),
+                            AuthConstraint(role=STEWARD, sig_count=1, need_to_be_owner=False,
+                                           metadata={PLUGIN_FIELD: 10}),
+                        ]))
+
+    req, actions = build_req_and_action(signatures={IDENTITY_OWNER: 1},
+                                        need_to_be_owner=True,
+                                        amount=5)
+
+    with pytest.raises(UnauthorizedClientRequest) as excinfo:
+        write_auth_req_validator.validate(req, actions)
+    assert ("Rule for this action is: 1 TRUSTEE signature is required OR"
+            " 1 STEWARD signature with 10 new_field is required") \
+           in str(excinfo.value)


### PR DESCRIPTION
- Fix/extend docs for AUTH_RULE and GET_AUTH_RULE
- Add docs about TAA and TAA_AML transactions and requests
- Add docs about Revocation transactions and requests
- Extend Auth Rules with TAA and TAA_AML
- Extend Auth Rules with a description on who is the owner for each action
- Remove anyone_can_write docs from Auth Rules
- Add more tests for error messages when metadata is set