### PR TITLE
[INDY-2105] Fixes debs build routin in CD pipeline

### DIFF
--- a/build-scripts/ubuntu-1604/Dockerfile
+++ b/build-scripts/ubuntu-1604/Dockerfile
@@ -7,14 +7,20 @@ RUN apt-get update -y && apt-get install -y \
         unzip \
         python3.5 \
         python3-pip \
-        python-setuptools \
         python3-venv \
     # fmp
         ruby \
         ruby-dev \
         rubygems \
         gcc \
-        make
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+# issues with pip>=10:
+# https://github.com/pypa/pip/issues/5240
+# https://github.com/pypa/pip/issues/5221
+RUN python3 -m pip install -U pip setuptools \
+    && pip3 list
 
 # install fpm
 RUN gem install --no-ri --no-rdoc rake fpm


### PR DESCRIPTION
- updates setuptools in docker env since old version from `ubuntu:xenial` leads to intermittent failures durinf `fpm` tool run