### PR TITLE
Fix restart_indy_node under supervisord

### DIFF
--- a/scripts/restart_indy_node_ubuntu1604.sh
+++ b/scripts/restart_indy_node_ubuntu1604.sh
@@ -21,8 +21,8 @@ elif [ "$INDY_CONTROL" = "supervisorctl" ]; then
   echo "Starting indy-node"
   supervisorctl start indy-node
 
-  echo "Restarting agent"
-  supervisorctl restart indy-node-control
+  echo "Killing indy-node-control so that it restarts"
+  kill -9 `supervisorctl pid indy-node-control`
 
 else
 


### PR DESCRIPTION
After the indy_node_control process downloads a new version of software, it invokes /usr/local/bin/restart_indy_node which then invoked `supervisorctl restart indy-node-control`.  Unfortunately this command is not atomic and is equivalent to `supervisorctl stop indy-node-control` followed by `supervisorctl start indy-node-control`, which results in NOT restarting indy-node-control because it has just stopped itself.

The fix is for indy-node-control to simply commit suicide so that supervisord will automatically restart the process; that is, from a supervisorctl perspective, we do not change the state of the indy-node-control service.

Signed-off-by: Keith Smith <bksmith@us.ibm.com>