### PR TITLE
nym dynamic validation check transaction w/out verkey or role

### DIFF
--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -109,10 +109,10 @@ class NymHandler(PNymHandler):
         is_owner = origin == owner
 
         updateKeys = [ROLE, VERKEY]
-        updateKeysInOperation = is_owner
+        updateKeysInOperationOrOwner = is_owner
         for key in updateKeys:
             if key in operation:
-                updateKeysInOperation = True
+                updateKeysInOperationOrOwner = True
                 newVal = operation[key]
                 oldVal = nym_data.get(key)
                 self.write_req_validator.validate(request,
@@ -121,7 +121,7 @@ class NymHandler(PNymHandler):
                                                                   old_value=oldVal,
                                                                   new_value=newVal,
                                                                   is_owner=is_owner)])
-        if not updateKeysInOperation:
+        if not updateKeysInOperationOrOwner:
             raise InvalidClientRequest(request.identifier, request.reqId)
 
     def _decode_state_value(self, encoded):

--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -109,8 +109,10 @@ class NymHandler(PNymHandler):
         is_owner = origin == owner
 
         updateKeys = [ROLE, VERKEY]
+        updateKeysInOperation = is_owner
         for key in updateKeys:
             if key in operation:
+                updateKeysInOperation = True
                 newVal = operation[key]
                 oldVal = nym_data.get(key)
                 self.write_req_validator.validate(request,
@@ -119,6 +121,8 @@ class NymHandler(PNymHandler):
                                                                   old_value=oldVal,
                                                                   new_value=newVal,
                                                                   is_owner=is_owner)])
+        if not updateKeysInOperation:
+            raise InvalidClientRequest(request.identifier, request.reqId)
 
     def _decode_state_value(self, encoded):
         if encoded:

--- a/indy_node/test/nym_txn/test_nym_auth_rules.py
+++ b/indy_node/test/nym_txn/test_nym_auth_rules.py
@@ -334,7 +334,7 @@ def test_nym_edit(
     if editor.verkey is None:  # skip that as well since it doesn't make sense
         return
 
-    if not ROLE in edit_op:  # skip if the update operation doesn't changes neither role nor verkey
+    if not ROLE in edit_op:  # skip if the update operation changes neither role nor verkey
         if not VERKEY in edit_op:
             return
 

--- a/indy_node/test/nym_txn/test_nym_auth_rules.py
+++ b/indy_node/test/nym_txn/test_nym_auth_rules.py
@@ -334,4 +334,8 @@ def test_nym_edit(
     if editor.verkey is None:  # skip that as well since it doesn't make sense
         return
 
+    if not ROLE in edit_op:  # skip if the update operation doesn't changes neither role nor verkey
+        if not VERKEY in edit_op:
+            return
+
     sign_and_validate(looper, txnPoolNodeSet[0], ActionIds.edit, editor, edit_op, did_ledger=edited)

--- a/indy_node/test/nym_txn/test_nym_no_role.py
+++ b/indy_node/test/nym_txn/test_nym_no_role.py
@@ -1,0 +1,40 @@
+import pytest
+from indy import did
+
+from plenum.common.exceptions import RequestRejectedException
+from plenum.common.constants import TRUSTEE_STRING
+from plenum.test.pool_transactions.helper import sdk_add_new_nym
+from plenum.test.helper import sdk_get_and_check_replies, sdk_sign_and_submit_op
+
+
+def test_new_DID_cannot_update_another_DID(looper,
+                                           sdk_pool_handle,
+                                           sdk_wallet_trustee,
+                                           sdk_wallet_handle):
+    """Create trustee"""
+    trustee_did, trustee_verkey = looper.loop.run_until_complete(
+        did.create_and_store_my_did(sdk_wallet_trustee[0], "{}"))
+
+    """Add trustee to ledger"""
+    sdk_add_new_nym(looper, sdk_pool_handle,
+                    sdk_wallet_trustee, 'newTrustee', TRUSTEE_STRING, verkey=trustee_verkey, dest=trustee_did)
+
+    """new DID (no role)"""
+    new_no_role_did, new_no_role_verkey = looper.loop.run_until_complete(
+        did.create_and_store_my_did(sdk_wallet_trustee[0], "{}"))
+
+    """Adding new DID (no role) to ledger"""
+    sdk_add_new_nym(looper, sdk_pool_handle,
+                    sdk_wallet_trustee,
+                    'noRole',
+                    verkey=new_no_role_verkey, dest=new_no_role_did)
+
+    """Nym transaction to update Trustee DID that makes no change to verkey or role"""
+    op = {'type': '1',
+          'dest': trustee_did
+          }
+
+    """Submitting the transaction fails"""
+    with pytest.raises(RequestRejectedException):
+        req = sdk_sign_and_submit_op(looper, sdk_pool_handle, sdk_wallet_trustee, op)
+        sdk_get_and_check_replies(looper, [req])

--- a/indy_node/test/request_handlers/test_nym_handler.py
+++ b/indy_node/test/request_handlers/test_nym_handler.py
@@ -98,6 +98,20 @@ def test_nym_dynamic_validation_for_existing_nym(nym_request: Request, nym_handl
         nym_handler.dynamic_validation(nym_request, 0)
 
 
+def test_nym_dynamic_validation_for_existing_nym_fails_with_no_changes(nym_handler: NymHandler,
+                                                                       creator):
+    nym_request = Request(identifier=creator,
+                          reqId=5,
+                          operation={'type': NYM,
+                                     'dest': randomString()})
+    add_to_idr(nym_handler.database_manager.idr_cache, nym_request.operation['dest'], None)
+    add_to_idr(nym_handler.database_manager.idr_cache, creator, STEWARD)
+
+    nym_handler.write_req_validator.validate = get_exception(True)
+    with pytest.raises(InvalidClientRequest):
+        nym_handler.dynamic_validation(nym_request, 0)
+
+
 def test_update_state(nym_request: Request, nym_handler: NymHandler):
     seq_no = 1
     txn_time = 1560241033


### PR DESCRIPTION
modifies nym transaction dynamic validation to check for `role` and `verkey` properties in the operation, fails if both are missing.