### PR TITLE
fix returned random size

### DIFF
--- a/indy_node/test/anon_creds/test_revoc_def_static_validation.py
+++ b/indy_node/test/anon_creds/test_revoc_def_static_validation.py
@@ -24,7 +24,7 @@ def _res_field_size(request, _lt_eq_gt):
     _valid_size = TAG_LIMIT_SIZE if _field == TAG else GENERAL_LIMIT_SIZE
 
     if _lt_eq_gt == 'lt':
-        return _expected, _field, random.randint(0, _valid_size - 1)
+        return _expected, _field, random.randint(1, _valid_size - 1)
     if _lt_eq_gt == 'eq':
         return _expected, _field, _valid_size
     return _expected, _field, random.randint(_valid_size + 1, 2 * _valid_size)


### PR DESCRIPTION
Signed-off-by: Brent Zundel <Brent.Zundel@gmail.com>

The random integer function currently allows a 0 to be returned if the `request.param` is `lt`, but if the returned 0 is then used by `revoc_def_req` as a parameter for `randomString` this will result in an error. Because the range is usually 0-255, this error is intermittent.

This PR adjusts the range of possible returned random values so that 1 is the lowest possible return value.