### PR TITLE
chore: Add workflow trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 name: indy-node-build
-on: [ push, pull_request ]
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
   workflow-setup:


### PR DESCRIPTION
This will let people trigger builds without a change.

Signed-off-by: Ry Jones <ry@linux.com>