### PR TITLE
Allow test report publishing to fail

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Publish Test Report
         uses: scacap/action-surefire-report@v1
+        continue-on-error: true
         with:
           check_name: Indy Node ${{ matrix.module }} ${{ matrix.slice }}/${{ strategy.job-total }} Test Report
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- The actions don't have access to publish test results to commits on a PR.
- This should not cause the job to fail.

Replicating the fix done for `indy-plenum`; https://github.com/hyperledger/indy-plenum/pull/1523

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>