### PR TITLE
fix uploading of deb files with the same name but different distribution

### DIFF
--- a/.github/actions/publish-deb/publishPackages
+++ b/.github/actions/publish-deb/publishPackages
@@ -26,7 +26,7 @@ for name in ${fileList}; do
   jfrog rt u \
     --deb ${distribution}/${component}/${architecture} \
     --spec ${uploadSpec}\
-    --spec-vars "SOURCE_DIR=${sourceDirectory};PACKAGE_NAME=${name};COMPONENT=${component};PACKAGE_STARTING_LETTER=${startingLetter};PACKAGE_SHORT_NAME=${shortName}" \
+    --spec-vars "SOURCE_DIR=${sourceDirectory};PACKAGE_NAME=${name};COMPONENT=${component};PACKAGE_STARTING_LETTER=${startingLetter};PACKAGE_SHORT_NAME=${shortName};DISTRIBUTION=${distribution}" \
     --detailed-summary
   echo "====================================================================================================================="
   echo

--- a/.github/actions/publish-deb/upload-spec.json
+++ b/.github/actions/publish-deb/upload-spec.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "pattern": "${SOURCE_DIR}/${PACKAGE_NAME}",
-      "target": "indy/pool/${COMPONENT}/${PACKAGE_STARTING_LETTER}/${PACKAGE_SHORT_NAME}/"
+      "target": "indy/pool/${DISTRIBUTION}/${COMPONENT}/${PACKAGE_STARTING_LETTER}/${PACKAGE_SHORT_NAME}/"
     }
   ]
 }


### PR DESCRIPTION
This PR rearranges the uploading structure of the debian files according to the changes made in Indy-Plenum in this [commit](https://github.com/hyperledger/indy-plenum/commit/52ddd72c0dec5f037396bf0e88acbd38d13cdb4d).
The new structure prevents errors in uploading of debian files with the same filename but build from a different distribution.
The new structure will be as follows:
- `indy/pool/xenial/[dev, main, rc, stable]`
- `indy/pool/bionic/[dev, main, rc, stable]`
- `indy/pool/focal/[dev, main, rc, stable]`

Signed-off-by: udosson <r.klemens@yahoo.de>