### PR TITLE
Update version of Indy SKD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(metadata['__file__'], 'r') as f:
 BASE_DIR = os.path.join(os.path.expanduser("~"), ".indy")
 
 tests_require = ['attrs==19.1.0', 'pytest==3.3.1', 'pytest-xdist==1.22.1', 'pytest-forked==0.2',
-                 'python3-indy==1.15.0-dev-1618', 'pytest-asyncio==0.8.0']
+                 'python3-indy==1.15.0-dev-1625', 'pytest-asyncio==0.8.0']
 
 setup(
     name=metadata['__title__'],


### PR DESCRIPTION
Update version of Indy SDK to the same version used in Indy-Plenum which is at `python3-indy==1.15.0-dev-1625`