### PR TITLE
Ubuntu 20.04: bug fix: added missing env of distribution in publish_artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -391,6 +391,7 @@ jobs:
     if: needs.workflow-setup.outputs.publish == 'true'
     env:
       GITHUB_REF: ${{ needs.workflow-setup.outputs.GITHUB_REF }}
+      distribution: ${{ needs.workflow-setup.outputs.distribution }}
     steps:
       - name: Check out code
         uses: actions/checkout@v1


### PR DESCRIPTION
The recently merged CI/CD pipeline in #1697 missed passing `distribution` as env variable in the `publish-artifacts` step. This PR fixes the issue so that the debian packages get uploaded to the correct directory.

Signed-off-by: udosson <r.klemens@yahoo.de>