### PR TITLE
changed pypi package of plenum to the newest one published by GHA 

### DIFF
--- a/.github/workflows/build/Dockerfile
+++ b/.github/workflows/build/Dockerfile
@@ -26,4 +26,10 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
 # install fpm
 RUN gem install --no-ri --no-rdoc rake fpm
 
+
+RUN pip3 install -U \
+    # TODO: Investigate why pyzmq has to be installed additionally
+    # This changed with switching from from 1.13.0.dev1034 (build and published by Jenkins instance of Sovrin) to version 1.13.0.dev143 (GHA)
+    'pyzmq==18.1.0'
+
 RUN indy_image_clean

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -73,7 +73,7 @@ def withTestEnv(body) {
 
         buildDocker("hyperledger/indy-node-ci", "ci/ubuntu.dockerfile ci").inside {
             echo 'Test: Install dependencies'
-            sh "pip install pip==10.0.0"
+            sh "pip install 'pip<10.0.0' 'pyzmq==18.1.0'"
             install()
             body.call('python')
         }

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum==1.13.0.dev1034',
+    install_requires=['indy-plenum==1.13.0.dev143',
                       'timeout-decorator==0.4.0',
                       'distro==1.3.0'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
This PR updates the version of the PyPI package of `indy-plenum`  from `1.13.0.dev1034` (build and published by Jenkins instance of Sovrin) to version `1.13.0.dev143`. This version was published in the latest successful GHA run from the `master` branch. The GHA run is at: https://github.com/hyperledger/indy-plenum/runs/3579890752?check_suite_focus=true

This change is the precondition to start migrating from https://repo.sovrin.org/deb/pool/xenial/ to https://hyperledger.jfrog.io/ui/native/indy/pool/xenial.
Also, this update is required to run the node system tests from https://github.com/hyperledger/indy-test-automation/ with the Debian files built and published in the new CI/CD pipeline.

