### PR TITLE
changed plenum version to 1.13.0.dev143 from GHA and fixed ci

### DIFF
--- a/.github/workflows/build/Dockerfile
+++ b/.github/workflows/build/Dockerfile
@@ -26,4 +26,10 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
 # install fpm
 RUN gem install --no-ri --no-rdoc rake fpm
 
+
+RUN pip3 install -U \
+    # TODO: Investigate why pyzmq has to be installed additionally
+    # This changed with switching from from 1.13.0.dev1034 (build and published by Jenkins instance of Sovrin) to version 1.13.0.dev143 (GHA)
+    'pyzmq==18.1.0'
+
 RUN indy_image_clean

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -73,7 +73,7 @@ def withTestEnv(body) {
 
         buildDocker("hyperledger/indy-node-ci", "ci/ubuntu.dockerfile ci").inside {
             echo 'Test: Install dependencies'
-            sh "pip install pip==10.0.0"
+            sh "pip install 'pip<10.0.0' 'pyzmq==18.1.0'"
             install()
             body.call('python')
         }

--- a/build-scripts/ubuntu-1604/Dockerfile
+++ b/build-scripts/ubuntu-1604/Dockerfile
@@ -19,8 +19,10 @@ RUN apt-get update -y && apt-get install -y \
 # issues with pip>=10:
 # https://github.com/pypa/pip/issues/5240
 # https://github.com/pypa/pip/issues/5221
-RUN python3 -m pip install -U pip setuptools \
-    && pip3 list
+RUN python3 -m pip install -U \
+    'pip<10.0.0' \
+    'setuptools<=50.3.2'
+  
 
 # install fpm
 RUN gem install --no-ri --no-rdoc rake fpm

--- a/ci/code-validation.dockerfile
+++ b/ci/code-validation.dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -y && apt-get install -y \
 	python3-nacl
 RUN pip3 install -U \ 
 	'pip<10.0.0' \
-	setuptools \
+	'setuptools<=50.3.2' \
 	pep8==1.7.1 \
 	pep8-naming==0.6.1 \
 	flake8==3.5.0

--- a/ci/pipeline.groovy
+++ b/ci/pipeline.groovy
@@ -148,7 +148,7 @@ def systemTests(Closure body) {
             def uid = sh(returnStdout: true, script: 'id -u').trim()
             docker.build("hyperledger/indy-node-ci", "--build-arg uid=$uid -f ci/ubuntu.dockerfile ci").inside {
                 sh """
-                    pip install pip==10.0.0
+                    pip install 'pip<10.0.0' 'pyzmq==18.1.0'
                     pip install .[tests] >$pipLogName
                 """
 

--- a/ci/ubuntu.dockerfile
+++ b/ci/ubuntu.dockerfile
@@ -11,13 +11,15 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
 RUN apt-get update -y && apt-get install -y \
     python3-nacl \
     ursa=0.3.2-2 \
-    libindy=1.15.0~1618-xenial \
+    libindy=1.15.0~1625-xenial \
 # rocksdb python wrapper
     libbz2-dev \
     zlib1g-dev \
     liblz4-dev \
     libsnappy-dev \
     rocksdb=5.8.8
+
+ENV PATH="/home/$user/$venv/bin:$PATH"
 
 RUN indy_ci_add_user $uid $user $venv
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum==1.13.0.dev1034',
+    install_requires=['indy-plenum==1.13.0.dev143',
                       'timeout-decorator==0.4.0',
                       'distro==1.3.0'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
This PR updates the version of the PyPI package of indy-plenum from 1.13.0.dev1034 (build and published by Jenkins instance of Sovrin) to version 1.13.0.dev143. This version was published in the latest successful GHA run from the master branch. The GHA run is at: https://github.com/hyperledger/indy-plenum/runs/3579890752?check_suite_focus=true

This change is the precondition to start migrating from https://repo.sovrin.org/deb/pool/xenial/ to https://hyperledger.jfrog.io/ui/native/indy/pool/xenial.
Also, this update is required to run the node system tests from https://github.com/hyperledger/indy-test-automation/ with the Debian files built and published in the new CI/CD pipeline.

Further, this PR contains some fixes for the Jenkins CI pipeline.

A successful run can be found at: https://github.com/udosson/indy-node/actions/runs/1413619194
The GHA run of this PR fails because the `build` image is updated.

Signed-off-by: udosson <r.klemens@yahoo.de>