### PR TITLE
updated version of setup-jfrog-cli to v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -397,7 +397,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v1
+        uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.INDY_ARTIFACTORY_REPO_CONFIG }}
 


### PR DESCRIPTION
Cherry-picked commit https://github.com/hyperledger/indy-node/commit/5994b3fab897d9e8f999400607670f5228627939 from master to upgrade version of `action/setup-jfrog-ci` to `v2`.

Signed-off-by: udosson <r.klemens@yahoo.de>