### PR TITLE
bump indy-plenum to version 1.13.0.dev169

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum==1.13.0.dev143',
+    install_requires=['indy-plenum==1.13.0.dev169',
                       'timeout-decorator==0.4.0',
                       'distro==1.3.0'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
bump indy-plenum to version `1.13.0.dev169`  from the most recent build at https://github.com/hyperledger/indy-plenum/actions/runs/1436144765

Signed-off-by: udosson <r.klemens@yahoo.de>