### PR TITLE
prepares indy-plenum package version of debian version depedency

### DIFF
--- a/build-scripts/ubuntu-1604/prepare-package.sh
+++ b/build-scripts/ubuntu-1604/prepare-package.sh
@@ -34,6 +34,10 @@ if [ "$distro_packages" = "debian-packages" ]; then
   #### ToDo adjust packages for the Cannonical archive for Ubuntu 20.04 (focal)
   sed -i "s~timeout-decorator~python3-timeout-decorator~" setup.py
   sed -i "s~distro~python3-distro~" setup.py
+  
+  echo -e "\n\nPrepares indy-plenum debian package version"
+  sed -i -r "s~indy-plenum==([0-9\.]+[0-9])(\.)?([a-z]+)~indy-plenum==\1\~\3~" setup.py
+    
 elif [ "$distro_packages" = "python-packages" ]; then
   echo -e "\nNo adaption of dependencies for python packages"
 else


### PR DESCRIPTION
This change is needed to replace the PyPI version of `plenum` with the version of the Debian artifact.
Otherwise, we run into this error:
`indy-node : Depends: indy-plenum (= 1.13.0.dev169) but 1.13.0~dev169 is to be installed`

Signed-off-by: udosson <r.klemens@yahoo.de>