### PR TITLE
bump version of indy plenum and added pypi versio to 3rd party artifacts

### DIFF
--- a/.github/workflows/build/Dockerfile.ubuntu-2004
+++ b/.github/workflows/build/Dockerfile.ubuntu-2004
@@ -10,7 +10,9 @@ RUN apt-get update -y && apt-get install -y \
     gnupg \
     apt-transport-https \
     ca-certificates \
-    apt-utils
+    apt-utils \
+    curl \
+    jq
 
 # ========================================================================================================
 # Update repository signing keys
@@ -69,7 +71,8 @@ RUN pip3 install -U \
 
 
 # install fpm
-RUN gem install --no-document rake fpm
+RUN gem install --no-document rake 
+RUN gem install --no-document fpm -v 1.13.1
 
 RUN apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*

--- a/build-scripts/ubuntu-2004/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-2004/build-3rd-parties.sh
@@ -10,6 +10,10 @@ function build_from_pypi {
 
     if [ -z "$2" ]; then
         PACKAGE_VERSION=""
+        # Get the most recent package version from PyPI to be included in the package name of the Debian artifact
+        curl -X GET "https://pypi.org/pypi/${PACKAGE_NAME}/json" > "${PACKAGE_NAME}.json"
+        PACKAGE_VERSION="==$(cat "${PACKAGE_NAME}.json" | jq --raw-output '.info.version')"
+        rm "${PACKAGE_NAME}.json"
     else
         PACKAGE_VERSION="==$2"
     fi
@@ -45,7 +49,7 @@ function build_from_pypi {
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 pushd `dirname ${SCRIPT_PATH}` >/dev/null
 
-build_from_pypi timeout-decorator 0.4.0
-build_from_pypi distro 1.3.0
+build_from_pypi timeout-decorator 
+build_from_pypi distro
 
 popd >/dev/null

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum==1.13.0.dev135',
+    install_requires=['indy-plenum==1.13.0.dev175',
                       'timeout-decorator>=0.5.0',
                       'distro>=1.5.0'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
This PR bumps the version of `Indy Plenum`  to `1.13.0.dev175`.
Also, this PR adds the most recent version names to the 3rd party artifacts.

Signed-off-by: udosson <r.klemens@yahoo.de>