### PR TITLE
set dependencies for the Cannocical archive

### DIFF
--- a/build-scripts/ubuntu-2004/prepare-package.sh
+++ b/build-scripts/ubuntu-2004/prepare-package.sh
@@ -31,9 +31,12 @@ if [ "$distro_packages" = "debian-packages" ]; then
   # Only used for the deb package builds, NOT for the PyPi package builds.
   # Update the package names to match the versions that are pre-installed on the os.
   echo -e "\nAdapt the dependencies for the Canonical archive"
-  #### ToDo adjust packages for the Cannonical archive for Ubuntu 20.04 (focal)
-  # sed -i "s~timeout-decorator~python3-timeout-decorator~" setup.py
-  # sed -i "s~distro~python3-distro~" setup.py
+  sed -i "s~timeout-decorator~python3-timeout-decorator~" setup.py
+  sed -i "s~distro~python3-distro~" setup.py
+
+  echo -e "\n\nPrepares indy-plenum debian package version"
+  sed -i -r "s~indy-plenum==([0-9\.]+[0-9])(\.)?([a-z]+)~indy-plenum==\1\~\3~" setup.py
+
 elif [ "$distro_packages" = "python-packages" ]; then
   echo -e "\nNo adaption of dependencies for python packages"
 else


### PR DESCRIPTION
This PR fixes the following error when installing indy-node from the Artifactory:
```bash
#10 3.567 The following packages have unmet dependencies:
#10 3.617  indy-node : Depends: indy-plenum (= 1.13.0.dev175) but 1.13.0~dev175 is to be installed
#10 3.617              Depends: timeout-decorator (>= 0.5.0) but it is not installable
#10 3.617              Depends: distro (>= 1.5.0) but it is not installable
```

Signed-off-by: udosson <r.klemens@yahoo.de>