### PR TITLE
Fix indy-plenum version reference in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
-    install_requires=['indy-plenum==1.13.0.dev169',
+    install_requires=['indy-plenum==1.13.0~dev169',
                       'timeout-decorator==0.4.0',
                       'distro==1.3.0'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
- The convention was changed inadvertently to a `.` rather than a `~`.  The overwhelming majority of `dev` releases use the `~`.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>