### PR TITLE
Fix pytest-asyncio deprecation warnings which are causing the tests to fail.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+asyncio_mode = auto
 testpaths =
     indy_common
     indy_node


### PR DESCRIPTION
- Set asyncio_mode = auto to support the new operating modes of pytest-asyncio>=0.17
  - https://github.com/pytest-dev/pytest-asyncio#modes

Signed-off-by: Wade Barnes <wade@neoterictech.ca>