### PR TITLE
Fix crash in `indy-node-control`

### DIFF
--- a/indy_common/config.py
+++ b/indy_common/config.py
@@ -101,7 +101,7 @@ PACKAGES_TO_HOLD = ['indy-plenum', 'indy-node',
                     # From indy-plenum:
                     'python3-ioflo', 'python3-orderedset', 'python3-base58', 'python3-prompt-toolkit', 'python3-rlp', 'python3-sha3',
                     'python3-libnacl', 'python3-six', 'python3-portalocker', 'python3-sortedcontainers',
-                    'python3-dateutil', 'python3-semver', 'python3-pygments', 'python3-psutil', 'python3-pyzmq', 'python3-intervaltree',
+                    'python3-dateutil', 'python3-semver', 'python3-psutil', 'python3-pyzmq',
                     'python3-jsonpickle', 'python3-rocksdb', 'python3-pympler', 'python3-packaging',
                     # From indy-node:
                     'python3-timeout-decorator', 'python3-distro']


### PR DESCRIPTION
- python3-pygments and python3-intervaltree do not exist as dependencies in plenum anymore.
- The `indy-node-control` crashes when trying to hold packages that don't exist.
- Fixes the issue found here; https://github.com/hyperledger/indy-test-automation/issues/113

Signed-off-by: Wade Barnes <wade@neoterictech.ca>