### PR TITLE
Remove Pip Imports for ubuntu20

### DIFF
--- a/.github/workflows/build/Dockerfile.ubuntu-1604
+++ b/.github/workflows/build/Dockerfile.ubuntu-1604
@@ -1,4 +1,5 @@
-FROM hyperledger/indy-core-baseci:0.0.3-master
+FROM hyperledger/indy-core-baseci:0.0.4
+
 LABEL maintainer="Hyperledger <hyperledger-indy@lists.hyperledger.org>"
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -73,7 +73,7 @@ def withTestEnv(body) {
 
         buildDocker("hyperledger/indy-node-ci", "ci/ubuntu.dockerfile ci").inside {
             echo 'Test: Install dependencies'
-            sh "pip install pip==10.0.0"
+            sh "pip install 'pyzmq==18.1.0'"
             install()
             body.call('python')
         }

--- a/ci/pipeline.groovy
+++ b/ci/pipeline.groovy
@@ -148,7 +148,7 @@ def systemTests(Closure body) {
             def uid = sh(returnStdout: true, script: 'id -u').trim()
             docker.build("hyperledger/indy-node-ci", "--build-arg uid=$uid -f ci/ubuntu.dockerfile ci").inside {
                 sh """
-                    pip install pip==10.0.0
+                    pip install 'pyzmq==18.1.0'
                     pip install .[tests] >$pipLogName
                 """
 

--- a/indy_node/__init__.py
+++ b/indy_node/__init__.py
@@ -14,7 +14,7 @@ PLUGIN_CLIENT_REQ_OP_TYPES = {}
 def setup_plugins():
     import sys
     import os
-    import pip
+    import importlib_metadata
     import importlib    # noqa
     from importlib.util import module_from_spec, spec_from_file_location    # noqa: E402
     from indy_common.config_util import getConfigOnce   # noqa: E402
@@ -50,7 +50,7 @@ def setup_plugins():
                           format(plugin_root))
     sys.path.insert(0, plugin_root.__path__[0])
     enabled_plugins = config.ENABLED_PLUGINS
-    installed_packages = {p.project_name: p for p in pip.get_installed_distributions()}
+    installed_packages = set(p.metadata["Name"] for p in importlib_metadata.distributions())
     for plugin_name in enabled_plugins:
         plugin = find_and_load_plugin(plugin_name, plugin_root, installed_packages)
         plugin_globals = plugin.__dict__

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(metadata['__file__'], 'r') as f:
 BASE_DIR = os.path.join(os.path.expanduser("~"), ".indy")
 
 tests_require = ['attrs>=20.3.0', 'pytest>=6.2.2', 'pytest-xdist>=2.2.1', 'pytest-forked>=1.3.0',
-                 'python3-indy==1.15.0-dev-1625', 'pytest-asyncio>=0.14.0']
+                 'python3-indy==1.16.0.post236', 'pytest-asyncio>=0.14.0']
 
 setup(
     name=metadata['__title__'],
@@ -54,7 +54,9 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
+
     install_requires=['indy-plenum==1.13.0.dev175',
+                      'importlib-metadata<3.0',
                       'timeout-decorator>=0.5.0',
                       'distro>=1.5.0'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
Removal of Pip Imports for ubuntu20
and 
version bump for indy-sdk (getting rid of pip complaining about wrong indy-sdk versions, which was fixed)

Signed-off-by: pSchlarb <p.schlarb@esatus.com>