### PR TITLE
fix importlib-metadata dependency

### DIFF
--- a/build-scripts/ubuntu-2004/prepare-package.sh
+++ b/build-scripts/ubuntu-2004/prepare-package.sh
@@ -28,12 +28,14 @@ echo -e "\n\nPrepares indy-node debian package version"
 sed -i -r "s~indy-node==([0-9\.]+[0-9])(\.)?([a-z]+)~indy-node==\1\~\3~" setup.py
 
 if [ "$distro_packages" = "debian-packages" ]; then
-  # Only used for the deb package builds, NOT for the PyPi package builds.
-  # Update the package names to match the versions that are pre-installed on the os.
+  # Update the package names to match the names that are available on the os.
   echo -e "\nAdapt the dependencies for the Canonical archive"
   sed -i "s~timeout-decorator~python3-timeout-decorator~" setup.py
   sed -i "s~distro~python3-distro~" setup.py
+  sed -i "s~importlib-metadata=~python3-importlib-metadata=~" setup.py
 
+
+  # Only used for the deb package builds, NOT for the PyPi package builds.
   echo -e "\n\nPrepares indy-plenum debian package version"
   sed -i -r "s~indy-plenum==([0-9\.]+[0-9])(\.)?([a-z]+)~indy-plenum==\1\~\3~" setup.py
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,11 @@ setup(
     )],
 
     install_requires=['indy-plenum==1.13.0.dev14',
-                      'importlib-metadata<3.0',
+                    # importlib-metadata needs to be pinned to 3.10.1 because from v4.0.0 the package
+                    # name ends in python3-importlib-metadata_0.0.0_amd64.deb
+                    # see also build-scripts/ubuntu-2004/build-3rd-parties.sh
+                    # https://github.com/hyperledger/indy-plenum/blob/eac38674252b539216be2c40bb13e53c5b70dad2/build-scripts/ubuntu-2004/build-3rd-parties.sh#L104-L106
+                      'importlib-metadata==3.10.1',
                       'timeout-decorator>=0.5.0',
                       'distro>=1.5.0'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
This should fix the wrong dependency in the indy-node .deb package.

> The following packages have unmet dependencies:
>  indy-node : Depends: importlib-metadata (< 3.0) but it is not installable

Signed-off-by: mgmgwi <guido.wischrop@mgm-tp.com>