### PR TITLE
Added Status Check for branch protection

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -4,11 +4,6 @@ on:
     branches:
       - ubuntu-20.04-upgrade
       - feature/did-indy*
-    paths:
-      - '**.py'
-      - '.github/**'
-      - 'build-scripts/**'
-      - 'bump_version.sh'
   workflow_dispatch: 
 
 jobs:
@@ -25,15 +20,28 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ steps.setup.outputs.GITHUB_REPOSITORY_NAME }} 
       distribution: ${{ steps.setup.outputs.distribution }}
       publish: ${{ steps.setup.outputs.publish }}
+      testsNeeded: ${{ steps.testsNeeded.outputs.testsNeeded }}
     steps:
       - name: checkout source code
         uses: actions/checkout@v2
       - name: setup
         id: setup
         uses: hyperledger/indy-shared-gha/.github/actions/workflow-setup@v1
+      - name: testsNeeded
+        id: testsNeeded
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            testsNeeded:
+              - '**.py'
+              - '.github/**'
+              - 'build-scripts/**'
+              - 'bump_version.sh'   
 
   lint:
     name: Lint
+    needs: [workflow-setup]
+    if: ${{ needs.workflow-setup.outputs.testsNeeded == 'true' }}
     uses: hyperledger/indy-shared-gha/.github/workflows/lint.yaml@v1
       
   build-image:
@@ -63,3 +71,11 @@ jobs:
       isDev: true
       isRC: false
       moduleName: indy_node
+
+  statusCheck:
+    name: statusCheck
+    runs-on: ubuntu-latest
+    needs: [workflow-setup, build_packages]
+    if: ${{ needs.workflow-setup.outputs.testsNeeded == 'false' || success() }}
+    steps:
+      - run: 'echo "Just a status Check (Always true, when executed) for branch protection rules(blocks merging while test are running and if tests fail)." '

--- a/.github/workflows/releasepr.yaml
+++ b/.github/workflows/releasepr.yaml
@@ -71,3 +71,10 @@ jobs:
       isDev: 'false'
       isRC: '${{ needs.release-infos.outputs.isPreRelease }}'
       moduleName: indy_node
+
+  statusCheck:
+    name: statusCheck
+    runs-on: ubuntu-latest
+    needs: [workflow-setup, build_packages]
+    steps:
+      - run: 'echo "Just a status Check (Always true, when executed) for branch protection rules(blocks merging while test are running and if tests fail)." '


### PR DESCRIPTION
Added `StatusCheck` job  (Always true, when executed) for the branch protection rules(blocks merging while test are running and if tests fail).
Job needs to be ran at least once to be able to select it in the branch protection rule settings.

Signed-off-by: pSchlarb <p.schlarb@esatus.com>