### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -36,7 +36,10 @@ complex design decision or a controversial PR.
 
 ## Maintainers
 
-* Alex - maintainer and scrum team lead. geo=western Russia; github, rocket.chat, jira=ashcherbakov
+
+## Emeritus Maintainers
+
 * Doug - maintainer. geo=Utah, USA; github=glowkey; rocket.chat, jira=DouglasWightman
+* Alex - maintainer and scrum team lead. geo=western Russia; github, rocket.chat, jira=ashcherbakov
 * Lovesh - maintainer and founder of codebase, often involved in advanced research
   instead of day-to-day scrum. geo=India; github; jira=lovesh; rocket.chat=LoveshHarchandani


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>