### PR TITLE
Fix dependency scheme

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -55,7 +55,7 @@ jobs:
                        libgflags-dev
           pip install packaging \
                       importlib_metadata==3.10.1 \
-                      indy-plenum==1.13.1rc3 \
+                      indy-plenum==1.13.1.rc3 \
                       pyzmq==22.3.0
       - name: Prepare package and set version
         run: |

--- a/build-scripts/ubuntu-2004/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-2004/build-3rd-parties.sh
@@ -49,6 +49,7 @@ function build_from_pypi {
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 pushd `dirname ${SCRIPT_PATH}` >/dev/null
 
+build_from_pypi importlib-metadata 3.10.1
 build_from_pypi timeout-decorator 
 build_from_pypi distro 1.7.0
 

--- a/build-scripts/ubuntu-2004/build-indy_node.sh
+++ b/build-scripts/ubuntu-2004/build-indy_node.sh
@@ -15,6 +15,9 @@ cp -r "${INPUT_PATH}/." "${TMP_DIR}"
 cd "${TMP_DIR}/build-scripts/ubuntu-2004"
 ./prepare-package.sh "${TMP_DIR}" indy_node "${VERSION}" debian-packages
 
+echo "Fetching the indy-plenum version from setup.py and converting it to deb format ..."
+plenumDebVersion=$(grep -oP "indy-plenum==\d+.\d+.\d+((-|.)?rc\d+)?" ${TMP_DIR}/setup.py | grep -oP "\d+.\d+.\d+((-|.)?rc\d+)?" | sed 's/\./\~/3')
+echo "plenumDebVersion: ${plenumDebVersion}"
 
 sed -i "s/{package_name}/${PACKAGE_NAME}/" "prerm"
 
@@ -29,6 +32,8 @@ fpm --input-type "python" \
     --depends at \
     --depends iptables \
     --depends libsodium23 \
+    --depends "indy-plenum(=${plenumDebVersion})" \
+    --python-disable-dependency "indy-plenum" \
     --no-python-fix-dependencies \
     --maintainer "Hyperledger <hyperledger-indy@lists.hyperledger.org>" \
     --before-install "preinst_node" \

--- a/build-scripts/ubuntu-2004/prepare-package.sh
+++ b/build-scripts/ubuntu-2004/prepare-package.sh
@@ -33,10 +33,6 @@ if [ "$distro_packages" = "debian-packages" ]; then
   sed -i "s~timeout-decorator~python3-timeout-decorator~" setup.py
   sed -i "s~distro~python3-distro~" setup.py
   sed -i "s~importlib-metadata=~python3-importlib-metadata=~" setup.py
-
-  # Only used for the deb package builds, NOT for the PyPi package builds.
-  echo -e "\n\nPrepares indy-plenum debian package version"
-  sed -i -r "s~indy-plenum==([0-9\.]+[0-9])(\.)?([a-z]+)~indy-plenum==\1\~\3~" setup.py
   
   echo "Preparing config files"
   GENERAL_CONFIG_DIR="\/etc\/indy"

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,9 @@ setup(
         (BASE_DIR, ['data/nssm_original.exe'])
     )],
 
-    install_requires=['indy-plenum==1.13.1rc3',
+    # Update ./build-scripts/ubuntu-xxxx/build-3rd-parties.sh when this list gets updated.
+    # - Excluding changes to indy-plenum.
+    install_requires=['indy-plenum==1.13.1.rc3',
                     # importlib-metadata needs to be pinned to 3.10.1 because from v4.0.0 the package
                     # name ends in python3-importlib-metadata_0.0.0_amd64.deb
                     # see also build-scripts/ubuntu-2004/build-3rd-parties.sh


### PR DESCRIPTION
- A fix for the dependency scheme related to indy-plenum.  Fixes the issue where the python package version installed using the deb package is different than the published python package.

- The issue was due to how the dependency options of `fpm` were being used.  The deb package build was using the python dependencies to define the deb package dependencies.  Since the deb and python package version numbers use slightly different formats for non-release (`dev` and `rc`) versions, the versions of the python dependencies (notably indy-plenum) were being set to match the deb version format in order to correctly define the deb dependencies.  This strategy has the unfortunate side affect of causing dependency issues with the python packages down the road.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>