### PR TITLE
Fix indy-node devcontainer build issues

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,7 +63,8 @@ RUN apt-get update -y && apt-get install -y \
 RUN pip3 install -U \
     # Required by setup.py
     setuptools==50.3.2 \
-    'pyzmq==22.3.0'
+    'pyzmq==22.3.0' \
+    Cython==0.29.36
 
 
 # install fpm

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,7 +67,7 @@ RUN pip3 install -U \
 
 
 # install fpm
-RUN gem install --no-document rake 
+RUN gem install --no-document rake
 RUN gem install --no-document fpm -v 1.14.2
 
 RUN apt-get -y autoremove \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,34 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/ubuntu
 {
-	"name": "Ubuntu",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
-		// Use hirsute or bionic on local arm64/Apple Silicon.
-		"args": { "VARIANT": "focal" }
-	},
+    "name": "Ubuntu",
+    "build": {
+        "dockerfile": "Dockerfile",
+        // Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
+        // Use hirsute or bionic on local arm64/Apple Silicon.
+        "args": { "VARIANT": "focal" }
+    },
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "mhutchie.git-graph",
+                "eamodio.gitlens",
+                "ms-python.python"
+            ],
+            // Set *default* container specific settings.json values on container create.
+            "settings": {}
+        }
+    },
 
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"mhutchie.git-graph",
-		"eamodio.gitlens",
-		"ms-python.python"
-	],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "pip install .[tests]"
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install .[tests]",
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	//"remoteUser": "vscode"
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    //"remoteUser": "vscode"
 }


### PR DESCRIPTION
This is a workaround to fix the indy-node devcontainer issues reported in https://github.com/hyperledger/indy-node/issues/1822.  The dependency issues are actually at the indy-plenum level.  I'll be opening a ticket for the issue there.

fixes: https://github.com/hyperledger/indy-node/issues/1822