### PR TITLE
Update to indy-plenum==1.13.1

### DIFF
--- a/.github/workflows/build/Dockerfile.ubuntu-2004
+++ b/.github/workflows/build/Dockerfile.ubuntu-2004
@@ -26,13 +26,13 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61 &&
 # Plenum
 #  - https://github.com/hyperledger/indy-plenum/issues/1546
 #  - Needed to pick up rocksdb=5.8.8
-RUN echo "deb  https://hyperledger.jfrog.io/artifactory/indy focal dev rc main"  >> /etc/apt/sources.list && \
+RUN echo "deb  https://hyperledger.jfrog.io/artifactory/indy focal dev rc stable"  >> /etc/apt/sources.list && \
     echo "deb http://security.ubuntu.com/ubuntu bionic-security main"  >> /etc/apt/sources.list && \
     echo "deb https://repo.sovrin.org/deb bionic master" >> /etc/apt/sources.list && \
     echo "deb https://repo.sovrin.org/sdk/deb bionic master" >> /etc/apt/sources.list
 
-RUN apt-get update -y && apt-get install -y rubygems python3-pip && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* 
+RUN apt-get update -y && apt-get install -y rubygems python3-pip && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
 
 # install fpm
-RUN gem install --no-document rake 
+RUN gem install --no-document rake
 RUN gem install --no-document fpm -v 1.14.2

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
 
     # Update ./build-scripts/ubuntu-xxxx/build-3rd-parties.sh when this list gets updated.
     # - Excluding changes to indy-plenum.
-    install_requires=['indy-plenum==1.13.1.dev1677853403',
+    install_requires=['indy-plenum==1.13.1',
                     # importlib-metadata needs to be pinned to 3.10.1 because from v4.0.0 the package
                     # name ends in python3-importlib-metadata_0.0.0_amd64.deb
                     # see also build-scripts/ubuntu-2004/build-3rd-parties.sh


### PR DESCRIPTION
This PR updates the indy-plenum version in `setup.py` to use `indy-plenum==1.13.1`.