### PR TITLE
Update action-download-artifact actions

### DIFF
--- a/.github/workflows/publishRelease.yaml
+++ b/.github/workflows/publishRelease.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Node deb Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: releasepr.yaml
@@ -58,7 +58,7 @@ jobs:
           name: indy_node-deb
           path: artifacts/indy_node-deb
       - name: Download Node python Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: releasepr.yaml
@@ -66,7 +66,7 @@ jobs:
           name: indy_node-python
           path: artifacts/indy_node-python
       - name: Download Node third party dependency Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: releasepr.yaml


### PR DESCRIPTION
- Update to the latest version of action-download-artifact.
- Do not update the indy-shared-gha actions to v2 on the 20.04 branch. v2 is for the 22.04 branch.